### PR TITLE
feat: support windows and cn hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "dev": "docpress dev",
     "preview": "docpress build && docpress preview",
     "// Build Docpress": "",
-    "build": "rm -rf dist/ && framework-builder",
+    "build": "rimraf dist/ && framework-builder",
     "// Release": "",
     "release": "release-me patch"
   },
@@ -66,6 +66,7 @@
     "docpress": "link:",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
+    "rimraf": "^3.0.2",
     "rollup": "^2.74.1",
     "tsx": "^3.12.1",
     "typescript": "^4.9.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ importers:
       react-dom: ^18.1.0
       rehype-pretty-code: ^0.3.2
       remark-gfm: ^3.0.1
+      rimraf: ^3.0.2
       rollup: ^2.74.1
       shiki: ^0.10.1
       tsx: ^3.12.1
@@ -53,6 +54,7 @@ importers:
       docpress: 'link:'
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
+      rimraf: 3.0.2
       rollup: 2.74.1
       tsx: 3.12.1
       typescript: 4.9.4
@@ -3296,6 +3298,13 @@ packages:
   /reusify/1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  /rimraf/3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    hasBin: true
+    dependencies:
+      glob: 7.1.6
+    dev: true
 
   /rollup/2.74.1:
     resolution: {integrity: sha512-K2zW7kV8Voua5eGkbnBtWYfMIhYhT9Pel2uhBk2WO5eMee161nPze/XRfvEQPFYz7KgrCCnmh2Wy0AMFLGGmMA==}

--- a/src/installSectionUrlHashs.ts
+++ b/src/installSectionUrlHashs.ts
@@ -30,6 +30,7 @@ function assertNavLink(navigationEl: HTMLElement, urlHash: string) {
   const parentNavLinkMatch = Array.from(navigationEl.querySelectorAll(`a[href="${window.location.pathname}"]`))
   assert(parentNavLinkMatch.length <= 1)
   if (parentNavLinkMatch.length === 0) return
+
   const navLinks: HTMLElement[] = Array.from(navigationEl.querySelectorAll(`a[href="${urlHash}"]`))
   assert(navLinks.length === 1, { urlHash })
 }

--- a/src/markdownHeadingsVitePlugin.ts
+++ b/src/markdownHeadingsVitePlugin.ts
@@ -1,4 +1,5 @@
 import { assert, determineSectionUrlHash } from '../src/utils/server'
+import os from 'os'
 
 export { markdownHeadingsVitePlugin }
 export type { MarkdownHeading }
@@ -79,6 +80,8 @@ function parseMarkdownHeading(line: string): MarkdownHeading & { headingHtml: st
   return heading
 }
 
+const isWindows = os.platform() === 'win32'
+
 function parseTitle(titleMarkdown: string): string {
   type Part = { nodeType: 'text' | 'code'; content: string }
   const parts: Part[] = []
@@ -121,7 +124,10 @@ function parseTitle(titleMarkdown: string): string {
   return titleHtml
 
   function serializeText(text: string) {
-    const textEscaped = text.split("'").join("\\'")
+    let textEscaped = text.split("'").join("\\'")
+    if (isWindows) {
+      textEscaped = textEscaped.replace(/\r/, '')
+    }
     return `{'${textEscaped}'}`
   }
 }

--- a/src/navigation/Navigation.tsx
+++ b/src/navigation/Navigation.tsx
@@ -45,7 +45,9 @@ function NavigationContent({
   }
 }) {
   const headings = getHeadingsWithComputedProps(pageContext)
+
   const headingsGrouped = groupHeadings(headings)
+
   return (
     <div id="navigation-content">
       <div className="nav-column" style={{ position: 'relative' }}>

--- a/src/utils/determineSectionUrlHash.ts
+++ b/src/utils/determineSectionUrlHash.ts
@@ -9,7 +9,7 @@ function determineSectionUrlHash(title: string): string | null {
     // https://stackoverflow.com/questions/990904/remove-accents-diacritics-in-a-string-in-javascript/37511463#37511463
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
-    .split(/[^a-z0-9]+/)
+    .split(/[^a-z0-9\u4E00-\u9FA5]+/)
     .filter(Boolean)
     .join('-')
 


### PR DESCRIPTION
Hi! Here I did two things:
1. Fix the `acorn: Unterminated string constant ` issue on Windows system
2. Support chinese url hash by `\u4E00-\u9FA5`. (I'm not sure if this approach is good. If not, please tell me and I'll fix it) 😁