### PR TITLE
fix(NoteWithoutIcon): remove leading space

### DIFF
--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -93,8 +93,12 @@ function NoteGeneric({
   return (
     <blockquote className={className} style={style}>
       <div style={{ marginBottom: 20 }} />
-      <span style={{ fontFamily: 'emoji' }}>{icon}</span>
-      <span style={{ width: iconMargin ?? undefined, display: 'inline-block' }}></span>{' '}
+      {icon && (
+        <>
+          <span style={{ fontFamily: 'emoji' }}>{icon}</span>
+          <span style={{ width: iconMargin ?? undefined, display: 'inline-block' }}></span>{' '}
+        </>
+      )}
       <div className="blockquote-content">{children}</div>
       <div style={{ marginTop: 20 }} />
     </blockquote>


### PR DESCRIPTION
The "TL;DR" blockquote at https://telefunc.com/RPC-vs-GraphQL-REST has a leading space:

<img width="826" alt="screenshot" src="https://github.com/user-attachments/assets/5243d45a-a987-4d95-bfe3-be6054d30ce2">