### PR TITLE
fix: show all result `maxResultsPerGroup={Infinity}

### DIFF
--- a/src/docsearch/DocSearchInstall.tsx
+++ b/src/docsearch/DocSearchInstall.tsx
@@ -17,6 +17,7 @@ function DocSearchInstall() {
         apiKey={algolia.apiKey}
         insights={true}
         hitComponent={Hit}
+        maxResultsPerGroup={Infinity}
       />
     </div>
   )


### PR DESCRIPTION
@brillout, 
I just remembered we haven’t applied this fix yet.