### PR TITLE
fix: avoid using `lvl0` as title in breadcrumbs when `hit.type === 'content'`

### DIFF
--- a/src/components/Algolia/Snippet.tsx
+++ b/src/components/Algolia/Snippet.tsx
@@ -28,10 +28,6 @@ export function Snippet<TItem extends StoredDocSearchHit>({
 
   if (!hit.__docsearch_parent && hit.type !== 'lvl1' && attribute !== 'content') {
     if (hit.type === 'content') {
-      const lvl0 =
-        getPropertyByPath(hit, `_snippetResult.hierarchy.lvl0.value`) || getPropertyByPath(hit, 'hierarchy.lvl0')
-      title = lvl0 ? `${lvl0} > ` : ''
-
       lvl2 = getPropertyByPath(hit, `_snippetResult.hierarchy.lvl2.value`) || getPropertyByPath(hit, 'hierarchy.lvl2')
       lvl2 = lvl2 ? ` > ${lvl2}` : ''
     } else {


### PR DESCRIPTION
Hi @brillout 

Please give it a try and let me know how it goes.

