### PR TITLE
fix: remove URL hash from search results for `lvl1` hits

### DIFF
--- a/src/components/Algolia/Hit.tsx
+++ b/src/components/Algolia/Hit.tsx
@@ -14,7 +14,7 @@ type HierarchyType = Exclude<DocSearchHit['type'], 'content'>
 
 function Hit({ hit }: HitProps) {
   return (
-    <a href={hit.type === 'lvl1' ? hit.url.split('#')[0] : hit.url}>
+    <a href={hit.url}>
       <div className="DocSearch-Hit-Container">
         {(hit as InternalDocSearchHit).__docsearch_parent && (
           <svg className="DocSearch-Hit-Tree" viewBox="0 0 24 54">

--- a/src/docsearch/DocSearchInstall.tsx
+++ b/src/docsearch/DocSearchInstall.tsx
@@ -21,6 +21,14 @@ function DocSearchInstall() {
         searchParameters={{
           filters: 'is_available:true',
         }}
+        transformItems={(hits) => {
+          hits.map((hit) => {
+            if (hit.type === 'lvl1') {
+              hit.url = hit.url.split('#')[0]
+            }
+          })
+          return hits
+        }}
       />
     </div>
   )


### PR DESCRIPTION
closes #30 

@brillout, wdyt of this ?