### PR TITLE
feat: Clickable links in code blocks (closes #51)

### DIFF
--- a/demo/pages/features/+Page.mdx
+++ b/demo/pages/features/+Page.mdx
@@ -55,7 +55,7 @@ import type { Config } from 'vike/types'
 export default {
   meta: {
     Page: {
-      // some comment
+      // some comment https://github.com/brillout/docpress#readme
        env: { server: true, client: true }, // [!code --]
        env: { server: true } // [!code ++]
     }
@@ -211,4 +211,12 @@ async function onNewTodo(text: string) {
     { text, authorId: user.id }
   )
 }
+```
+
+
+## Links in code blocks
+
+```ts
+// https://vike.dev
+const a: number = 1
 ```

--- a/src/shikiTransformerAutoLinks.ts
+++ b/src/shikiTransformerAutoLinks.ts
@@ -13,7 +13,6 @@ function shikiTransformerAutoLinks(): ShikiTransformer {
   return {
     name: 'docpress-shiki-autolinks',
     span(span) {
-      // Only process spans that have a single text node as their child.
       if (span.children.length !== 1) return
       let child = span.children[0]
       if (child.type !== 'text') return
@@ -39,7 +38,6 @@ function shikiTransformerAutoLinks(): ShikiTransformer {
           newChildren.unshift({ type: 'text', value: postValue })
         }
 
-        // Insert a clickable `<a>` element for the URL.
         newChildren.unshift({
           type: 'element',
           tagName: 'a',

--- a/src/shikiTransformerAutoLinks.ts
+++ b/src/shikiTransformerAutoLinks.ts
@@ -18,7 +18,6 @@ function shikiTransformerAutoLinks(): ShikiTransformer {
       let child = span.children[0]
       if (child.type !== 'text') return
 
-      // Find all matching URLs in the text node's value using the regex.
       const links: { href: string; index: number }[] = []
       const matches = Array.from(child.value.matchAll(linkRE))
 
@@ -31,14 +30,11 @@ function shikiTransformerAutoLinks(): ShikiTransformer {
         links.unshift({ href, index: match.index })
       }
 
-      // Prepare a new list of children to replace the original span's children.
       const newChildren: typeof span.children = []
-      // Iterate over the matched links.
       for (const { href, index } of links) {
         const postIndex = index + href.length
         const postValue = child.value.slice(postIndex)
 
-        // Preserve any text after the URL as a text node.
         if (postValue.length > 0) {
           newChildren.unshift({ type: 'text', value: postValue })
         }
@@ -51,19 +47,16 @@ function shikiTransformerAutoLinks(): ShikiTransformer {
           children: [{ type: 'text', value: href }],
         })
 
-        // Update remaining text before the URL for the next iteration.
         child = {
           type: 'text',
           value: child.value.slice(0, index),
         }
       }
 
-      // Add any remaining text before the first URL.
       if (child.value.length > 0) {
         newChildren.unshift(child)
       }
 
-      // Replace the original span's children.
       span.children = newChildren
     },
   }

--- a/src/shikiTransformerAutoLinks.ts
+++ b/src/shikiTransformerAutoLinks.ts
@@ -35,7 +35,7 @@ function shikiTransformerAutoLinks(): ShikiTransformer {
         newChildren.unshift({
           type: 'element',
           tagName: 'a',
-          properties: { href, target: '_blank' },
+          properties: { href },
           children: [{ type: 'text', value: href }],
         })
 

--- a/src/shikiTransformerAutoLinks.ts
+++ b/src/shikiTransformerAutoLinks.ts
@@ -1,0 +1,55 @@
+export { shikiTransformerAutoLinks }
+
+import type { ShikiTransformer } from 'shiki'
+
+const linkRE = /https:\/\/[^\s]*[^.,\s"'`]/g
+
+function shikiTransformerAutoLinks(): ShikiTransformer {
+  return {
+    name: 'docpress-shiki-autolinks',
+    span(span) {
+      if (span.children.length !== 1) return
+      let child = span.children[0]
+      if (child.type !== 'text') return
+
+      const links: { href: string; index: number }[] = []
+      const matches = Array.from(child.value.matchAll(linkRE))
+
+      // Filter out URLs that contain `${...}`. e.g. `https://star-wars.brillout.com/api/films/${id}.json`
+      const filtered = matches.filter(([href]) => !href.includes('${'))
+      if (filtered.length === 0) return
+
+      for (const match of filtered) {
+        const [href] = match
+        links.unshift({ href, index: match.index })
+      }
+
+      const newChildren: typeof span.children = []
+      for (const { href, index } of links) {
+        const postIndex = index + href.length
+        const postValue = child.value.slice(postIndex)
+
+        if (postValue.length > 0) {
+          newChildren.unshift({ type: 'text', value: postValue })
+        }
+        newChildren.unshift({
+          type: 'element',
+          tagName: 'a',
+          properties: { href, target: '_blank' },
+          children: [{ type: 'text', value: href }],
+        })
+
+        child = {
+          type: 'text',
+          value: child.value.slice(0, index),
+        }
+      }
+
+      if (child.value.length > 0) {
+        newChildren.unshift(child)
+      }
+
+      span.children = newChildren
+    },
+  }
+}

--- a/src/shikiTransformerAutoLinks.ts
+++ b/src/shikiTransformerAutoLinks.ts
@@ -4,18 +4,25 @@ import type { ShikiTransformer } from 'shiki'
 
 const linkRE = /https:\/\/[^\s]*[^.,\s"'`]/g
 
+/**
+ * A Shiki transformer that converts plain HTTPS URLs in code blocks into clickable `<a>` links.
+ *
+ * Inspired by `@jcayzac/shiki-transformer-autolinks`, but tailored for a narrower use case.
+ */
 function shikiTransformerAutoLinks(): ShikiTransformer {
   return {
     name: 'docpress-shiki-autolinks',
     span(span) {
+      // Only process spans that have a single text node as their child.
       if (span.children.length !== 1) return
       let child = span.children[0]
       if (child.type !== 'text') return
 
+      // Find all matching URLs in the text node's value using the regex.
       const links: { href: string; index: number }[] = []
       const matches = Array.from(child.value.matchAll(linkRE))
 
-      // Filter out URLs that contain `${...}`. e.g. `https://star-wars.brillout.com/api/films/${id}.json`
+      // Filter out URLs that contain `${...}`. e.g. `https://star-wars.brillout.com/api/films/${id}.json`.
       const filtered = matches.filter(([href]) => !href.includes('${'))
       if (filtered.length === 0) return
 
@@ -24,14 +31,19 @@ function shikiTransformerAutoLinks(): ShikiTransformer {
         links.unshift({ href, index: match.index })
       }
 
+      // Prepare a new list of children to replace the original span's children.
       const newChildren: typeof span.children = []
+      // Iterate over the matched links.
       for (const { href, index } of links) {
         const postIndex = index + href.length
         const postValue = child.value.slice(postIndex)
 
+        // Preserve any text after the URL as a text node.
         if (postValue.length > 0) {
           newChildren.unshift({ type: 'text', value: postValue })
         }
+
+        // Insert a clickable `<a>` element for the URL.
         newChildren.unshift({
           type: 'element',
           tagName: 'a',
@@ -39,16 +51,19 @@ function shikiTransformerAutoLinks(): ShikiTransformer {
           children: [{ type: 'text', value: href }],
         })
 
+        // Update remaining text before the URL for the next iteration.
         child = {
           type: 'text',
           value: child.value.slice(0, index),
         }
       }
 
+      // Add any remaining text before the first URL.
       if (child.value.length > 0) {
         newChildren.unshift(child)
       }
 
+      // Replace the original span's children.
       span.children = newChildren
     },
   }

--- a/src/vite.config.ts
+++ b/src/vite.config.ts
@@ -9,11 +9,16 @@ import remarkGfm from 'remark-gfm'
 import { transformerNotationDiff } from '@shikijs/transformers'
 import { remarkDetype } from './remarkDetype.js'
 import { rehypeMetaToProps } from './rehypeMetaToProps.js'
+import { shikiTransformerAutoLinks } from './shikiTransformerAutoLinks.js'
 
 const root = process.cwd()
 const prettyCode = [
   rehypePrettyCode,
-  { theme: 'github-light', keepBackground: false, transformers: [transformerNotationDiff()] },
+  {
+    theme: 'github-light',
+    keepBackground: false,
+    transformers: [transformerNotationDiff(), shikiTransformerAutoLinks()],
+  },
 ]
 const rehypePlugins: any = [prettyCode, [rehypeMetaToProps]]
 const remarkPlugins = [remarkGfm, remarkDetype]


### PR DESCRIPTION
This PR adds a custom Shiki transformer (`shikiTransformerAutoLinks()`) that detects `https://` links in code blocks and wraps them with `<a>` tags, making them clickable in the rendered output.

✅ Changes

- Matches `https://` links in code block content using RegEx.
- Skips transforming links that contain `${...}`.
- Wraps valid links with anchor tags (`<a href=...>`, with `target="_blank"`) while preserving syntax highlighting and formatting.