### PR TITLE
fix: load `+docpress` at build time (`meta.env.config === true`) (closes #86)

### DIFF
--- a/src/+config.ts
+++ b/src/+config.ts
@@ -18,7 +18,7 @@ const config = {
   hydrationCanBeAborted: true,
   meta: {
     docpress: {
-      env: { server: true, client: true },
+      env: { server: true, client: true, config: true },
       global: true,
     },
   },

--- a/src/package.json
+++ b/src/package.json
@@ -50,7 +50,7 @@
     "./renderer/onRenderHtml": "./renderer/onRenderHtml.tsx",
     "./renderer/onRenderClient": "./renderer/onRenderClient.tsx",
     "./renderer/onCreatePageContext": "./renderer/onCreatePageContext.ts",
-    ".": "./index.ts",
+    ".": "./dist/index.js",
     "./config": "./dist/+config.js",
     "./style": "./css/index.css",
     "./types": {


### PR DESCRIPTION
Let's try finishing this after we merge https://github.com/brillout/docpress/pull/73.