### PR TITLE
fix: prevent `undefined` entries in `URLs` list

### DIFF
--- a/src/resolvePageContext.ts
+++ b/src/resolvePageContext.ts
@@ -152,8 +152,8 @@ function getActiveHeading(
   const URLs =
     '\n' +
     [...headingsResolved, ...headingsDetachedResolved]
-      .filter(Boolean)
       .map((h) => h.url)
+      .filter(Boolean)
       .sort()
       .map((url) => `  ${url}`)
       .join('\n')


### PR DESCRIPTION
@brillout 

Previously, the URLs result was:
```
  /
  /blog/post-1
  /blog/post-2
  /error
  /features
  /languages
  /notes
  /orphan
  /orphan-2
  /page-1
  /page-2
  /page-3
  /page-4
  /press
  /pricing
  /releases/2024-06
  /some-page
  /tiny
  undefined
  undefined
  undefined
  undefined
  undefined
  undefined
  undefined
  undefined
```

With this fix, the result is now:
```
  /
  /blog/post-1
  /blog/post-2
  /error
  /features
  /languages
  /notes
  /orphan
  /orphan-2
  /page-1
  /page-2
  /page-3
  /page-4
  /press
  /pricing
  /releases/2024-06
  /some-page
  /tiny
  ```