### PR TITLE
fix: import docsearch css by file path to avoid Vite resolve error

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -7,4 +7,4 @@
 @import './code.css';
 @import './table.css';
 @import './tooltip.css';
-@import '@docsearch/css';
+@import '@docsearch/css/dist/style.css';


### PR DESCRIPTION
Needed to integrate `tailwind/vite` in vike docs repo.

Vite Tailwind generate:serve fails when resolving `@docsearch/css` from CSS. Use explicit dist style path to keep styles and avoid resolver issue.