### PR TITLE
🐛 fix: prevent tailwind height override for nav icons

### DIFF
--- a/src/ExternalLinks.tsx
+++ b/src/ExternalLinks.tsx
@@ -109,7 +109,7 @@ function LinkIcon({
         href={href}
         style={{ padding: 3, display: 'inline-flex', lineHeight: 0, height: '100%', alignItems: 'center' }}
       >
-        <img className={className} src={icon} height={height} width="auto" style={{ ...style, height }} />
+        <img className={className} src={icon} height={height} style={{ ...style, height }} />
       </a>
     </>
   )


### PR DESCRIPTION
when adding tailwind to vike I stumbled upon a icon sizing issue:

<img width="1692" height="837" alt="Bildschirmfoto 2026-02-01 um 01 33 16" src="https://github.com/user-attachments/assets/08ce146d-2d50-4f74-92d9-1657f3a2e0b7" />

resulting from the default application of styles from tailwind:

<img width="439" height="93" alt="Bildschirmfoto 2026-02-01 um 01 46 43" src="https://github.com/user-attachments/assets/5e524e31-8a50-422c-aca1-c905009cefe4" />

I applied the height as style property to fix that