### PR TITLE
polish `remarkPkgManager`

### DIFF
--- a/src/code-blocks/remarkPkgManager.ts
+++ b/src/code-blocks/remarkPkgManager.ts
@@ -24,7 +24,7 @@ function remarkPkgManager() {
           node.position?.start.line
         }. Replace it with the equivalent 'npm' command for the package manager toggle to work.`,
       )
-      if (node.value.includes('npm ') && node.value.includes('npx ')) return
+      if (!node.value.includes('npm ') && !node.value.includes('npx ')) return
       let choice: string | undefined = undefined
       const nodes = new Map<string, Code>()
 


### PR DESCRIPTION
@brillout, wdyt of this changes ?

> Another additional safe check we can add is to check whether `convert()` leads to a diff.

I don’t think that’s necessary. We just need to check if `node.value` contains `pnpm`, show a warning, replace all occurrences with `npm`, and continue the process.