### PR TITLE
fix: sort DocSearch `hits` to prioritize non-anchor URLs

### DIFF
--- a/src/docsearch/DocSearchInstall.tsx
+++ b/src/docsearch/DocSearchInstall.tsx
@@ -27,6 +27,7 @@ function DocSearchInstall() {
               hit.url = hit.url.split('#')[0]!
             }
           })
+          hits.sort((a, b) => Number(a.url.includes('#')) - Number(b.url.includes('#')))
           return hits
         }}
       />


### PR DESCRIPTION
closes #105 