### PR TITLE
refactor: remove unnecessary mapping in DocSearch transformItems()

### DIFF
--- a/src/docsearch/DocSearchInstall.tsx
+++ b/src/docsearch/DocSearchInstall.tsx
@@ -23,9 +23,6 @@ function DocSearchInstall() {
           hitsPerPage: 50,
         }}
         transformItems={(hits) => {
-          hits.map((hit) => {
-            if (hit.type === 'lvl1') hit.url = hit.url.split('#')[0]!
-          })
           hits.sort((a, b) => Number(a.url.includes('#')) - Number(b.url.includes('#')))
           return hits
         }}


### PR DESCRIPTION
This is because `<h1>` elements no longer have an id ([dfd93e8](https://github.com/brillout/docpress/commit/dfd93e8a8c97c9dbac29d7225df639aadcff86bf)).