### PR TITLE
fix: improve handling of hidden state in choice-group parent-child merging

### DIFF
--- a/src/code-blocks/components/ChoiceGroup.tsx
+++ b/src/code-blocks/components/ChoiceGroup.tsx
@@ -51,7 +51,7 @@ function CustomSelectsContainer({ children }: { children: React.ReactNode }) {
             ...(parentChoiceGroup && {
               parentChoiceGroup: {
                 ...parentChoiceGroup,
-                choices: [parentChoiceGroup.choice],
+                choices: !choiceGroup.hidden ? [parentChoiceGroup.choice] : [],
               },
             }),
           },
@@ -61,7 +61,9 @@ function CustomSelectsContainer({ children }: { children: React.ReactNode }) {
       if (!parentChoiceGroup || !existing.parentChoiceGroup) return prev
 
       const existingChoices = existing.parentChoiceGroup.choices
-      const mergedChoices = new Set([...existingChoices, parentChoiceGroup.choice])
+      if (!choiceGroup.hidden) existing.parentChoiceGroup.choices.push(parentChoiceGroup.choice)
+
+      const mergedChoices = new Set([...existing.parentChoiceGroup.choices])
       if (mergedChoices.size === existingChoices.length) return prev
 
       const next = [...prev]
@@ -152,7 +154,7 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
   function isHidden() {
     if (parentChoiceGroup) {
       const [parentSelectedChoice] = useSelectedChoice(parentChoiceGroup.name, parentChoiceGroup.default)
-      return !parentChoiceGroup.choices.includes(parentSelectedChoice) || hidden
+      return !parentChoiceGroup.choices.includes(parentSelectedChoice)
     }
     return hidden
   }


### PR DESCRIPTION
Ensure hidden choice groups don’t contribute to `parentChoiceGroup.choices` and refine visibility logic by:

- skipping `parentChoiceGroup.choices` injection when `choiceGroup.hidden` is true
- removing redundant hidden check in `isHidden()` when `parentChoiceGroup` exists