### PR TITLE
refactor: rename `useSelectedChoice` to `useCurrentSelection`

### DIFF
--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -27,7 +27,7 @@ import {
 } from './MenuModal/toggleMenuModal.js'
 import { MenuModal } from './MenuModal.js'
 import { autoScrollNav_SSR } from './autoScrollNav.js'
-import { initializeChoiceGroup_SSR } from './code-blocks/hooks/useSelectedChoice.js'
+import { initializeChoiceGroup_SSR } from './code-blocks/hooks/useCurrentSelection.js'
 import { SearchLink } from './docsearch/SearchLink.js'
 import { navigate } from 'vike/client/router'
 import { css } from './utils/css.js'

--- a/src/code-blocks/components/ChoiceGroup.tsx
+++ b/src/code-blocks/components/ChoiceGroup.tsx
@@ -1,7 +1,7 @@
 export { ChoiceGroup, CustomSelectsContainer }
 
 import React, { createContext, useContext, useEffect, useState } from 'react'
-import { useSelectedChoice } from '../hooks/useSelectedChoice.js'
+import { useCurrentSelection } from '../hooks/useCurrentSelection.js'
 import { useRestoreScroll } from '../hooks/useRestoreScroll.js'
 import { cls } from '../../utils/cls.js'
 import './ChoiceGroup.css'
@@ -93,8 +93,7 @@ type ChoiceGroupProps = {
 
 function ChoiceGroup({ children, choiceGroup, parentChoiceGroup }: ChoiceGroupProps) {
   const { name: groupName, choices, default: defaultChoice, lvl } = choiceGroup
-  // TODO/after-PR-merge rename useSelectedChoice useCurrentSelection
-  const [selectedChoice] = useSelectedChoice(groupName, defaultChoice)
+  const [selectedChoice] = useCurrentSelection(groupName, defaultChoice)
   const { choiceGroupAll, registerChoiceGroup } = useCustomSelectsContext()
 
   useEffect(() => registerChoiceGroup(choiceGroup, parentChoiceGroup), [])
@@ -133,7 +132,7 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
     hidden,
     parentChoiceGroup,
   } = choiceGroup
-  const [selectedChoice, setSelectedChoice] = useSelectedChoice(groupName, defaultChoice)
+  const [selectedChoice, setSelectedChoice] = useCurrentSelection(groupName, defaultChoice)
   const prevPositionRef = useRestoreScroll([selectedChoice])
   const [expanded, setExpanded] = useState(false)
   const selectedIndex = choices.indexOf(selectedChoice)
@@ -153,7 +152,7 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
   }
   function isHidden() {
     if (parentChoiceGroup) {
-      const [parentSelectedChoice] = useSelectedChoice(parentChoiceGroup.name, parentChoiceGroup.default)
+      const [parentSelectedChoice] = useCurrentSelection(parentChoiceGroup.name, parentChoiceGroup.default)
       return !parentChoiceGroup.choices.includes(parentSelectedChoice)
     }
     return hidden

--- a/src/code-blocks/hooks/useCurrentSelection.ts
+++ b/src/code-blocks/hooks/useCurrentSelection.ts
@@ -1,4 +1,4 @@
-export { useSelectedChoice }
+export { useCurrentSelection }
 export { initializeChoiceGroup_SSR }
 
 import { useLocalStorage } from './useLocalStorage.js'
@@ -12,7 +12,7 @@ const keyPrefix = 'docpress'
  * @param defaultValue Default choice value.
  * @returns `[selectedChoice, setSelectedChoice]`.
  */
-function useSelectedChoice(choiceGroupName: string, defaultValue: string) {
+function useCurrentSelection(choiceGroupName: string, defaultValue: string) {
   return useLocalStorage(`${keyPrefix}:choice:${choiceGroupName}`, defaultValue)
 }
 


### PR DESCRIPTION
@brillout,
Is it correct to use ‘fix:’ here?