### PR TITLE
fix: improve hidden logic for ChoiceGroup dropdown rendering

### DIFF
--- a/src/code-blocks/components/ChoiceGroup.tsx
+++ b/src/code-blocks/components/ChoiceGroup.tsx
@@ -109,7 +109,7 @@ function ChoiceGroup({ children, choiceGroup, parentChoiceGroup }: ChoiceGroupPr
         ))}
       </select>
       {children}
-      {lvl === 0 && (
+      {lvl === 0 && !choiceGroup.hidden && (
         <div className={`choice-group__selects`}>
           {choiceGroupAll
             .slice()

--- a/src/code-blocks/utils/generateChoiceGroupCode.ts
+++ b/src/code-blocks/utils/generateChoiceGroupCode.ts
@@ -25,6 +25,11 @@ const CHOICES_BUILT_IN: Record<string, { choices: string[]; default: string }> =
 
 function generateChoiceGroupCode(choiceNodes: ChoiceNode[], parent: Parent, hide: boolean = false): MdxJsxFlowElement {
   let lvl: number = 0
+  const customHidden = choiceNodes.some((node) =>
+    node.children.some((node) => node.type === 'containerDirective' && node.children[0]!.type !== 'code'),
+  )
+  const hidden = hide || customHidden
+
   const { choiceGroup, mergedChoiceNodes } = resolveChoiceGroupNodes(choiceNodes)
   const attributes: MdxJsxAttribute[] = []
   const children: MdxJsxFlowElement[] = []
@@ -66,7 +71,7 @@ function generateChoiceGroupCode(choiceNodes: ChoiceNode[], parent: Parent, hide
   }
 
   attributes.push(
-    expressionToAttribute('choiceGroup', { ...choiceGroup, hidden: choiceNodes.length === 1 || hide, lvl }),
+    expressionToAttribute('choiceGroup', { ...choiceGroup, hidden: choiceNodes.length === 1 || hidden, lvl }),
   )
 
   const choiceGroupNode: MdxJsxFlowElement = {


### PR DESCRIPTION
Update hidden logic so that choice groups are marked hidden when any `containerDirective` has a first child that is not a `code` node. This ensures visibility is determined strictly by the first child node type, aligning behavior with the intended directive structure.