### PR TITLE
fix: group `jsx|tsx` and `vue` code blocks together

### DIFF
--- a/src/code-blocks/remarkChoiceGroup.ts
+++ b/src/code-blocks/remarkChoiceGroup.ts
@@ -16,7 +16,10 @@ function remarkChoiceGroup() {
         const { choice } = meta.props
         node.meta = meta.rest
 
-        if (choice) node.data ??= { customDataChoice: choice, customDataFilter: `code-${node.lang}` }
+        if (choice) {
+          const filter = ['jsx', 'tsx', 'vue'].includes(node.lang ?? '') ? 'code-component' : `code-${node.lang}`
+          node.data ??= { customDataChoice: choice, customDataFilter: filter }
+        }
       }
       if (node.type === 'containerDirective' && node.name === 'Choice') {
         if (!node.attributes) return


### PR DESCRIPTION
This updates the choice grouping logic for code blocks so that jsx, tsx, and vue are treated as a single component group when a `choice=` meta is present.

Example
~~~mdx
```tsx choice=vike-react
// React code
```

```vue choice=vike-vue
<!-- Vue code -->
```

```tsx choice=vike-solid
// Solid code
```
~~~

Previously, Vue was separated from JSX/TSX-based code blocks.