### PR TITLE
fix: hide empty choices from dropdown and tab list

### DIFF
--- a/demo/+docpress.tsx
+++ b/demo/+docpress.tsx
@@ -49,7 +49,7 @@ const config: Config = {
   navMaxWidth: 1140,
   choices: {
     server: {
-      choices: ['Hono', 'Express', 'Fastify'],
+      choices: ['Hono', 'Express', 'Fastify', 'H3'],
       default: 'Hono',
     },
     uiFrameworkVikeExtension: {

--- a/demo/pages/features/+Page.mdx
+++ b/demo/pages/features/+Page.mdx
@@ -251,7 +251,9 @@ npm install fastify fastify-raw-body @photonjs/fastify
 
 Using the `<Tabs choice="choice-name">` component to also display tabbed choices:
 
-<Tabs choice={'server'} />
+> Passing `hiddenChoices={['choice-name']}` to hide specific choices from the tab list.
+
+<Tabs choice={'server'} hiddenChoices={['H3']} />
 
 ```ts choice=Hono file-added
 // server/index.ts

--- a/src/code-blocks/components/ChoiceGroup.tsx
+++ b/src/code-blocks/components/ChoiceGroup.tsx
@@ -9,8 +9,8 @@ import './ChoiceGroup.css'
 type TChoiceGroup = {
   name: string
   choices: string[]
+  emptyChoices: string[]
   default: string
-  disabled: string[]
   hidden: boolean
   lvl: number
 }
@@ -124,31 +124,20 @@ function ChoiceGroup({ children, choiceGroup, parentChoiceGroup }: ChoiceGroupPr
 }
 
 function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
-  const {
-    name: groupName,
-    choices,
-    default: defaultChoice,
-    disabled: disabledChoices,
-    hidden,
-    parentChoiceGroup,
-  } = choiceGroup
+  const { name: groupName, choices, emptyChoices, default: defaultChoice, hidden, parentChoiceGroup } = choiceGroup
   const [selectedChoice, setSelectedChoice] = useCurrentSelection(groupName, defaultChoice)
   const setPrevPosition = useRestoreScroll([selectedChoice])
   const [expanded, setExpanded] = useState(false)
-  const selectedIndex = choices.indexOf(selectedChoice)
+
+  const isEmptyChoice = (choice: string) => emptyChoices.includes(choice)
+  const filteredChoices = choices.filter((choice) => !isEmptyChoice(choice))
+  const selectedIndex = filteredChoices.indexOf(selectedChoice)
   const height = 25
   const rectTop = -selectedIndex * height
 
-  const isDisabled = (choice: string) => disabledChoices.includes(choice)
   function next() {
-    let nextIndex = selectedIndex
-    for (let i = 0; i < choices.length; i++) {
-      nextIndex = (nextIndex + 1) % choices.length
-      if (!isDisabled(choices[nextIndex]!)) {
-        setSelectedChoice(choices[nextIndex]!)
-        return
-      }
-    }
+    const nextIndex = (selectedIndex + 1) % filteredChoices.length
+    setSelectedChoice(filteredChoices[nextIndex]!)
   }
   function isHidden() {
     if (parentChoiceGroup) {
@@ -163,7 +152,7 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
       id={`choicesFor-${groupName}`}
       aria-haspopup="listbox"
       aria-expanded={expanded}
-      className={cls(['choice-select', (isHidden() || isDisabled(selectedChoice)) && 'hidden'])}
+      className={cls(['choice-select', (isHidden() || isEmptyChoice(selectedChoice)) && 'hidden'])}
       style={{ height }}
       onMouseEnter={() => setExpanded(true)}
       onMouseLeave={() => setExpanded(false)}
@@ -175,14 +164,13 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
         aria-activedescendant={`choice-${selectedChoice}`}
         role="listbox"
         className="choice-select__list"
-        style={{ top: rectTop, height: choices.length * height }}
+        style={{ top: rectTop, height: filteredChoices.length * height }}
       >
-        {choices.map((choice, i) => (
+        {filteredChoices.map((choice, i) => (
           <div
             id={choice}
             key={i}
             aria-selected={i === selectedIndex}
-            aria-disabled={isDisabled(choice)}
             role="option"
             className="choice-select__option"
             style={{ height }}
@@ -200,7 +188,7 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
     setPrevPosition(el)
     if (el.getAttribute('aria-selected') === 'true') {
       next()
-    } else if (el.getAttribute('aria-disabled') === 'false') {
+    } else {
       setSelectedChoice(el.id)
     }
   }

--- a/src/code-blocks/components/Tabs.tsx
+++ b/src/code-blocks/components/Tabs.tsx
@@ -7,7 +7,7 @@ import { usePageContext } from '../../renderer/usePageContext.js'
 import { assertUsage } from '../../utils/assert.js'
 import './Tabs.css'
 
-function Tabs({ choice }: { choice: string }) {
+function Tabs({ choice, hiddenChoices = [] }: { choice: string; hiddenChoices: string[] }) {
   const groupName = choice
   const pageContext = usePageContext()
   const choicesAll = pageContext.config.docpress.choices
@@ -16,7 +16,9 @@ function Tabs({ choice }: { choice: string }) {
   const { choices, default: defaultChoice } = choicesAll[groupName]
   const [selectedChoice, setSelectedChoice] = useCurrentSelection(groupName, defaultChoice)
   const setPrevPosition = useRestoreScroll([selectedChoice])
-  const selectedIndex = choices.indexOf(selectedChoice)
+  const isHidden = (choice: string) => hiddenChoices.includes(choice)
+  const filteredChoices = choices.filter((choice) => !isHidden(choice))
+  const selectedIndex = filteredChoices.indexOf(selectedChoice)
 
   return (
     <div className="choice-tabs" data-choice-group={groupName}>
@@ -33,6 +35,7 @@ function Tabs({ choice }: { choice: string }) {
           <li
             key={i}
             id={choice}
+            style={{ display: isHidden(choice) ? 'none' : undefined }}
             className="choice-tabs__tab"
             role="tab"
             aria-selected={i === selectedIndex}
@@ -59,16 +62,16 @@ function Tabs({ choice }: { choice: string }) {
 
     switch (e.key) {
       case 'ArrowRight':
-        nextIndex = (selectedIndex + 1) % choices.length
+        nextIndex = (selectedIndex + 1) % filteredChoices.length
         break
       case 'ArrowLeft':
-        nextIndex = (selectedIndex - 1 + choices.length) % choices.length
+        nextIndex = (selectedIndex - 1 + filteredChoices.length) % filteredChoices.length
         break
       case 'Home':
         nextIndex = 0
         break
       case 'End':
-        nextIndex = choices.length - 1
+        nextIndex = filteredChoices.length - 1
         break
       default:
         return
@@ -76,7 +79,7 @@ function Tabs({ choice }: { choice: string }) {
 
     e.preventDefault()
     setPrevPosition(el)
-    const nextChoice = choices[nextIndex]!
+    const nextChoice = filteredChoices[nextIndex]!
     setSelectedChoice(nextChoice)
     const tabEl = el.parentElement?.parentElement as HTMLDivElement
 

--- a/src/code-blocks/utils/generateChoiceGroupCode.ts
+++ b/src/code-blocks/utils/generateChoiceGroupCode.ts
@@ -108,12 +108,12 @@ function resolveChoiceGroupNodes(choiceNodes: ChoiceNode[]) {
   })
   assertUsage(groupName, `Missing group name for [${choices}]. Define it in +docpress.choices.`)
 
-  const disabled = choicesAll[groupName]!.choices.filter((choice) => !choices.includes(choice))
+  const emptyChoices = choicesAll[groupName]!.choices.filter((choice) => !choices.includes(choice))
 
   const choiceGroup = {
     name: groupName,
     ...choicesAll[groupName]!,
-    disabled,
+    emptyChoices,
   }
 
   const mergedChoiceNodes: ChoiceNode[] = choiceGroup.choices.map((choice) => {


### PR DESCRIPTION
To hide specific tab choices in Tabs, `hiddenChoices: string[]` must be passed, since there is no shared source of truth like in `ChoiceGroup`.