### PR TITLE
fix: prevent choice-dropdown and copy-button from overlapping incorrectly (#146)

### DIFF
--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -17,7 +17,6 @@
   .choice-select {
     background: #eee;
     font-size: 13.3333px;
-    z-index: 3;
 
     -webkit-user-select: none; /* Safari */
     -moz-user-select: none; /* Firefox */
@@ -58,7 +57,7 @@
   .choice-select[aria-expanded='true'] {
     overflow: visible;
     border-width: 0;
-    z-index: 5;
+    z-index: 1;
 
     .choice-select__list {
       border-style: solid;

--- a/src/code-blocks/components/Pre.css
+++ b/src/code-blocks/components/Pre.css
@@ -17,7 +17,6 @@ pre {
     position: absolute !important;
     top: 10px;
     right: 10px;
-    z-index: 3;
     margin: 0;
     height: 25px;
     width: 30px;

--- a/src/code-blocks/components/Pre.tsx
+++ b/src/code-blocks/components/Pre.tsx
@@ -30,8 +30,8 @@ function Pre({ children, ...props }: React.ComponentPropsWithoutRef<'pre'> & Add
       className={cls([className, props['file-added'] && classAdded, props['file-removed'] && classRemoved])}
       {...rest}
     >
-      {!props['hide-menu'] && <CopyButton />}
       {children}
+      {!props['hide-menu'] && <CopyButton />}
     </pre>
   )
 }


### PR DESCRIPTION
closes #146 