### PR TITLE
Refactor Select and Tabs components to use radio inputs (UI polish)

### DIFF
--- a/demo/testRun.ts
+++ b/demo/testRun.ts
@@ -130,7 +130,7 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
     await expectJs()
 
     if (!isDev) {
-      await page.getByLabel('TypeScript').first().check()
+      await page.getByLabel('TypeScript').first().click()
     }
 
     await autoRetry(
@@ -211,7 +211,7 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
     }
 
     const expectFastifyChoice = async () => {
-      await page.getByLabel('Fastify').first().check()
+      await page.getByLabel('Fastify').first().click()
       const text = await getVisibleText(page)
       hasHonoChoice(text, false)
       hasExpressChoice(text, false)
@@ -223,8 +223,8 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
     await expectHonoChoice()
 
     if (!isDev) {
-      await page.getByLabel('pnpm').first().check()
-      await page.getByLabel('Express').first().check()
+      await page.getByLabel('pnpm').first().click()
+      await page.getByLabel('Express').first().click()
     }
 
     await autoRetry(

--- a/demo/testRun.ts
+++ b/demo/testRun.ts
@@ -130,7 +130,7 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
     await expectJs()
 
     if (!isDev) {
-      await page.locator('#choicesFor-codeLang').first().getByRole('option', { name: 'TypeScript' }).click()
+      await page.getByLabel('TypeScript').first().check()
     }
 
     await autoRetry(
@@ -211,7 +211,7 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
     }
 
     const expectFastifyChoice = async () => {
-      await page.locator('#choicesFor-server').first().getByRole('option', { name: 'Fastify' }).click()
+      await page.getByLabel('Fastify').first().check()
       const text = await getVisibleText(page)
       hasHonoChoice(text, false)
       hasExpressChoice(text, false)
@@ -223,8 +223,8 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
     await expectHonoChoice()
 
     if (!isDev) {
-      await page.locator('#choicesFor-pkgManager').first().getByRole('option', { name: 'pnpm' }).click()
-      await page.locator('#choicesFor-server').first().getByRole('option', { name: 'Express' }).click()
+      await page.getByLabel('pnpm').first().check()
+      await page.getByLabel('Express').first().check()
     }
 
     await autoRetry(

--- a/demo/testRun.ts
+++ b/demo/testRun.ts
@@ -130,7 +130,7 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
     await expectJs()
 
     if (!isDev) {
-      await page.getByLabel('TypeScript').first().click()
+      await page.locator('#choice-TypeScript').first().click()
     }
 
     await autoRetry(
@@ -211,7 +211,7 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
     }
 
     const expectFastifyChoice = async () => {
-      await page.getByLabel('Fastify').first().click()
+      await page.locator('#choice-Fastify').first().click()
       const text = await getVisibleText(page)
       hasHonoChoice(text, false)
       hasExpressChoice(text, false)
@@ -223,8 +223,8 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
     await expectHonoChoice()
 
     if (!isDev) {
-      await page.getByLabel('pnpm').first().click()
-      await page.getByLabel('Express').first().click()
+      await page.locator('#choice-pnpm').first().click()
+      await page.locator('#choice-Express').first().click()
     }
 
     await autoRetry(

--- a/demo/testRun.ts
+++ b/demo/testRun.ts
@@ -130,7 +130,7 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
     await expectJs()
 
     if (!isDev) {
-      await page.locator('#choice-TypeScript').first().click()
+      await page.locator('#choice-TypeScript').first().dispatchEvent('click')
     }
 
     await autoRetry(
@@ -211,7 +211,7 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
     }
 
     const expectFastifyChoice = async () => {
-      await page.locator('#choice-Fastify').first().click()
+      await page.locator('#choice-Fastify').first().dispatchEvent('click')
       const text = await getVisibleText(page)
       hasHonoChoice(text, false)
       hasExpressChoice(text, false)
@@ -223,8 +223,8 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
     await expectHonoChoice()
 
     if (!isDev) {
-      await page.locator('#choice-pnpm').first().click()
-      await page.locator('#choice-Express').first().click()
+      await page.locator('#choice-pnpm').first().dispatchEvent('click')
+      await page.locator('#choice-Express').first().dispatchEvent('click')
     }
 
     await autoRetry(

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -125,6 +125,10 @@
     }
   }
 
+  .choice-select__option:not(:last-child) {
+    box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.1);
+  }
+
   .choice-select__option:hover {
     background: #f5f5f5;
   }

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -91,7 +91,6 @@
   .choice-select[aria-expanded='false'] {
     overflow: hidden;
     border-width: 1px 2px 2px 1px;
-    transition: overflow 0s 180ms allow-discrete, z-index 0s 180ms allow-discrete;
 
     .choice-select__option:has(.choice-select__radio:checked) {
       opacity: 1;

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -21,9 +21,9 @@
     position: absolute;
     display: flex;
     flex-direction: row-reverse;
-    gap: 4px;
+    gap: 5px;
     top: var(--top-position);
-    right: 44px;
+    right: 45px;
   }
 
   .choice-select {
@@ -38,7 +38,7 @@
 
     border: none;
     border-radius: var(--border-radius);
-    box-shadow: 0.8px 0.8px 0 hsl(0, 0%, 75%), 2px 2px 0 hsl(0, 0%, 72%);
+    box-shadow: 0.8px 0.8px 0px 1.8px hsl(0, 0%, 75%), 2px 2px 0px 1px hsl(0, 0%, 72%);
     overflow: hidden;
   }
 
@@ -46,6 +46,7 @@
     position: relative;
     top: 0;
     border-radius: var(--border-radius);
+    box-shadow: 0.8px 0.8px 0px 1.8px hsl(0, 0%, 75%), 2px 2px 0px 1px hsl(0, 0%, 72%);
     width: 100%;
   }
 
@@ -119,19 +120,26 @@
 
     &:has(.choice-select__option:active) {
       box-shadow: none;
+      .choice-select__option {
+        box-shadow: none;
+      }
     }
 
     .choice-select__list {
       transition: var(--transition-select-list-expand);
-      box-shadow: 0.8px 0.8px 0 hsl(0, 0%, 75%), 2px 2px 0 hsl(0, 0%, 72%);
+      box-shadow: 0.8px 0.8px 0px 1.8px hsl(0, 0%, 72%), 2px 2px 0px 1px hsl(0, 0%, 66%);
 
       &:has(.choice-select__option:active) {
-        box-shadow: 0.8px 0.8px 0 hsl(0, 0%, 75%), 1.2px 1.2px 0 hsl(0, 0%, 72%);
+        box-shadow: 0.8px 0.8px 0px 1.8px hsl(0, 0%, 75%), 1.2px 1.2px 0px 1px hsl(0, 0%, 72%);
       }
     }
 
     .choice-select__option {
       opacity: 1;
+
+      &:active {
+        box-shadow: inset 1.2px 1.2px hsl(0, 0%, 66%), inset -0.8px -0.8px hsl(0, 0%, 72%) !important;
+      }
     }
   }
 

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -96,8 +96,11 @@
     }
   }
 
-  .choice-select__list:not([aria-expanded='true']) {
-    transition: none !important;
+  .choice-select__list:not(.hovered) {
+    transition: none;
+    .choice-select__border {
+      transition: none;
+    }
   }
 
   .choice-select__option:not(:last-child) {

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -27,6 +27,7 @@
     border: none;
     border-radius: var(--border-radius);
     box-shadow: 0.8px 0.8px 0 hsl(0, 0%, 75%), 2px 2px 0 hsl(0, 0%, 72%);
+    overflow: hidden;
   }
 
   .choice-select__list {
@@ -34,8 +35,7 @@
     top: 0;
     border-radius: var(--border-radius);
     width: 100%;
-    overflow: hidden;
-    transition: top 180ms cubic-bezier(0.2, 0.9, 0.2, 1);
+    transition: top 180ms cubic-bezier(0.2, 0.9, 0.2, 1), box-shadow 180ms ease;
   }
 
   .choice-select__option {
@@ -49,8 +49,7 @@
     box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.1);
     cursor: pointer;
     opacity: 0;
-    transform: translateY(0.5px);
-    transition: background 120ms ease, opacity 180ms ease, transform 180ms ease;
+    transition: background 120ms ease, opacity 180ms ease-out, box-shadow 180ms ease-out;
   }
 
   .choice-select__radio {
@@ -88,32 +87,30 @@
   }
 
   .choice-select[aria-expanded='false'] {
-    overflow: hidden;
-
     .choice-select__option:has(.choice-select__radio:checked) {
       box-shadow: none;
       opacity: 1;
-      transform: translateY(0);
     }
   }
 
   .choice-select[aria-expanded='true'] {
     overflow: visible;
-    box-shadow: none;
     z-index: 1;
+
+    &:has(.choice-select__option:active) {
+      box-shadow: none;
+    }
 
     .choice-select__list {
       box-shadow: 0.8px 0.8px 0 hsl(0, 0%, 75%), 2px 2px 0 hsl(0, 0%, 72%);
 
       &:has(.choice-select__option:active) {
-        transition: box-shadow 180ms ease;
         box-shadow: 0.8px 0.8px 0 hsl(0, 0%, 75%), 1.2px 1.2px 0 hsl(0, 0%, 72%);
       }
     }
 
     .choice-select__option {
       opacity: 1;
-      transform: translateY(0);
     }
   }
 

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -96,6 +96,10 @@
     }
   }
 
+  .choice-select__list:not([aria-expanded='true']) {
+    transition: none !important;
+  }
+
   .choice-select__option:not(:last-child) {
     box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.1);
   }

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -111,12 +111,6 @@
     background: #eee;
   }
 
-  .choice-select__option:has(.choice-select__radio:disabled) {
-    color: #999;
-    cursor: not-allowed;
-    opacity: 0.8;
-  }
-
   .hidden {
     display: none !important;
   }

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -66,18 +66,6 @@
     transition: var(--transition-select-option);
   }
 
-  .choice-select__radio {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
-
   .choice-select__option-content {
     display: inline-flex;
     align-items: center;

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -5,13 +5,10 @@
   --top-position: 10px;
   --border-radius: 5px;
   --transition-select-duration-1: 1000ms;
-  --transition-select-duration-2: 1500ms;
-  --transition-select-duration-3: 1500ms;
-  --transition-select: overflow var(--transition-select-duration-2) allow-discrete ease-in;
-  --transition-select-list-expand: top var(--transition-select-duration-3) cubic-bezier(0.2, 0.9, 0.2, 1), box-shadow
-    var(--transition-select-duration-3) ease;
-  --transition-select-list-collapse: top var(--transition-select-duration-1) cubic-bezier(0.2, 0.9, 0.2, 1), box-shadow
-    var(--transition-select-duration-1) ease;
+  --transition-select-duration-2: 1000ms;
+  --transition-select: overflow var(--transition-select-duration-2) 100ms allow-discrete ease-in;
+  --transition-select-list: top var(--transition-select-duration-1) cubic-bezier(0.2, 0.9, 0.2, 1), box-shadow
+    var(--transition-select-duration-1) ease, clip-path var(--transition-select-duration-1) ease-in-out;
   --transition-select-option: background var(--transition-select-duration-1) ease, opacity
     var(--transition-select-duration-1) ease-out, box-shadow var(--transition-select-duration-1) ease-out, border-radius
     var(--transition-select-duration-1) ease-in-out;
@@ -39,7 +36,6 @@
     border: none;
     border-radius: var(--border-radius);
     box-shadow: 0.8px 0.8px 0px 1.8px hsl(0, 0%, 75%), 2px 2px 0px 1px hsl(0, 0%, 72%);
-    overflow: hidden;
   }
 
   .choice-select__list {
@@ -48,6 +44,7 @@
     border-radius: var(--border-radius);
     box-shadow: 0.8px 0.8px 0px 1.8px hsl(0, 0%, 75%), 2px 2px 0px 1px hsl(0, 0%, 72%);
     width: 100%;
+    transition: var(--transition-select-list);
   }
 
   .choice-select__option {
@@ -98,12 +95,6 @@
   }
 
   .choice-select[aria-expanded='false'] {
-    transition: var(--transition-select);
-
-    .choice-select__list {
-      transition: var(--transition-select-list-collapse);
-    }
-
     .choice-select__option {
       box-shadow: none;
 
@@ -115,7 +106,6 @@
   }
 
   .choice-select[aria-expanded='true'] {
-    overflow: visible;
     z-index: 1;
 
     &:has(.choice-select__option:active) {
@@ -126,7 +116,7 @@
     }
 
     .choice-select__list {
-      transition: var(--transition-select-list-expand);
+      clip-path: inset(0px round var(--border-radius)) !important;
       box-shadow: 0.8px 0.8px 0px 1.8px hsl(0, 0%, 72%), 2px 2px 0px 1px hsl(0, 0%, 66%);
 
       &:has(.choice-select__option:active) {
@@ -166,24 +156,31 @@
 
   .choice-select:has(.choice-select__option:nth-of-type(1) .choice-select__radio:checked) .choice-select__list {
     top: calc(0 * var(--option-height));
+    clip-path: inset(calc(0 * var(--option-height)) 0 calc( (var(--choice-count) - 0 - 1) * var(--option-height)) 0 round var(--border-radius));
   }
   .choice-select:has(.choice-select__option:nth-of-type(2) .choice-select__radio:checked) .choice-select__list {
     top: calc(-1 * var(--option-height));
+    clip-path: inset(calc(1 * var(--option-height)) 0 calc( (var(--choice-count) - 1 - 1) * var(--option-height)) 0 round var(--border-radius));
   }
   .choice-select:has(.choice-select__option:nth-of-type(3) .choice-select__radio:checked) .choice-select__list {
     top: calc(-2 * var(--option-height));
+    clip-path: inset(calc(2 * var(--option-height)) 0 calc( (var(--choice-count) - 2 - 1) * var(--option-height)) 0 round var(--border-radius));
   }
   .choice-select:has(.choice-select__option:nth-of-type(4) .choice-select__radio:checked) .choice-select__list {
     top: calc(-3 * var(--option-height));
+    clip-path: inset(calc(3 * var(--option-height)) 0 calc( (var(--choice-count) - 3 - 1) * var(--option-height)) 0 round var(--border-radius));
   }
   .choice-select:has(.choice-select__option:nth-of-type(5) .choice-select__radio:checked) .choice-select__list {
     top: calc(-4 * var(--option-height));
+    clip-path: inset(calc(4 * var(--option-height)) 0 calc( (var(--choice-count) - 4 - 1) * var(--option-height)) 0 round var(--border-radius));
   }
   .choice-select:has(.choice-select__option:nth-of-type(6) .choice-select__radio:checked) .choice-select__list {
     top: calc(-5 * var(--option-height));
+    clip-path: inset(calc(5 * var(--option-height)) 0 calc( (var(--choice-count) - 5 - 1) * var(--option-height)) 0 round var(--border-radius));
   }
   .choice-select:has(.choice-select__option:nth-of-type(7) .choice-select__radio:checked) .choice-select__list {
     top: calc(-6 * var(--option-height));
+    clip-path: inset(calc(6 * var(--option-height)) 0 calc( (var(--choice-count) - 6 - 1) * var(--option-height)) 0 round var(--border-radius));
   }
 }
 

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -4,11 +4,13 @@
   /* layout */
   --top-position: 10px;
   --border-radius: 5px;
-  --transition-select-duration-1: 1800ms;
-  --transition-select-duration-2: 1800ms;
+  --transition-select-duration-1: 1000ms;
+  --transition-select-duration-2: 1500ms;
+  --transition-select-duration-3: 1500ms;
   --transition-select: overflow var(--transition-select-duration-2) allow-discrete ease-in;
-  --transition-select-list: top var(--transition-select-duration-1) cubic-bezier(0.2, 0.9, 0.2, 1), box-shadow var(--transition-select-duration-1) ease;
-  --transition-select-option: background var(--transition-select-duration-2) ease, opacity var(--transition-select-duration-1) ease-out, box-shadow var(--transition-select-duration-1) ease-out;
+  --transition-select-list-expand: top var(--transition-select-duration-3) cubic-bezier(0.2, 0.9, 0.2, 1), box-shadow var(--transition-select-duration-3) ease;
+  --transition-select-list-collapse: top var(--transition-select-duration-1) cubic-bezier(0.2, 0.9, 0.2, 1), box-shadow var(--transition-select-duration-1) ease;
+  --transition-select-option: background var(--transition-select-duration-1) ease, opacity var(--transition-select-duration-1) ease-out, box-shadow var(--transition-select-duration-1) ease-out;
   --transition-select-icon: filter 500ms ease, opacity 500ms ease;
 
   .choice-group__selects {
@@ -41,7 +43,6 @@
     top: 0;
     border-radius: var(--border-radius);
     width: 100%;
-    transition: var(--transition-select-list);
   }
 
   .choice-select__option {
@@ -94,6 +95,10 @@
   .choice-select[aria-expanded='false'] {
     transition: var(--transition-select);
 
+    .choice-select__list {
+      transition: var(--transition-select-list-collapse);
+    }
+
     .choice-select__option {
       box-shadow: none;
 
@@ -112,6 +117,7 @@
     }
 
     .choice-select__list {
+      transition: var(--transition-select-list-expand);
       box-shadow: 0.8px 0.8px 0 hsl(0, 0%, 75%), 2px 2px 0 hsl(0, 0%, 72%);
 
       &:has(.choice-select__option:active) {

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -3,15 +3,15 @@
 
   /* layout */
   --top-position: 10px;
-  --border-color: hsl(0, 0%, 75%) hsl(0, 0%, 72%) hsl(0, 0%, 72%) hsl(0, 0%, 75%);
+  --border-radius: 5px;
 
   .choice-group__selects {
     position: absolute;
     display: flex;
     flex-direction: row-reverse;
-    gap: 2px;
+    gap: 4px;
     top: var(--top-position);
-    right: 42px;
+    right: 44px;
   }
 
   .choice-select {
@@ -24,16 +24,15 @@
     -ms-user-select: none; /* IE/Edge legacy */
     user-select: none; /* Standard */
 
-    border-radius: 5px;
-    border-style: solid;
-    border-color: var(--border-color);
+    border: none;
+    border-radius: var(--border-radius);
+    box-shadow: 0.8px 0.8px 0 hsl(0, 0%, 75%), 2px 2px 0 hsl(0, 0%, 72%);
   }
 
   .choice-select__list {
     position: relative;
     top: 0;
-    border-radius: 5px;
-    border-color: var(--border-color);
+    border-radius: var(--border-radius);
     width: 100%;
     overflow: hidden;
     transition: top 180ms cubic-bezier(0.2, 0.9, 0.2, 1);
@@ -47,7 +46,7 @@
     flex-wrap: nowrap;
     background: #fff;
     padding: 0 6px;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.1);
     cursor: pointer;
     opacity: 0;
     transform: translateY(0.5px);
@@ -90,9 +89,9 @@
 
   .choice-select[aria-expanded='false'] {
     overflow: hidden;
-    border-width: 1px 2px 2px 1px;
 
     .choice-select__option:has(.choice-select__radio:checked) {
+      box-shadow: none;
       opacity: 1;
       transform: translateY(0);
     }
@@ -100,12 +99,16 @@
 
   .choice-select[aria-expanded='true'] {
     overflow: visible;
-    border-width: 0;
+    box-shadow: none;
     z-index: 1;
 
     .choice-select__list {
-      border-style: solid;
-      border-width: 1px 2px 2px 1px;
+      box-shadow: 0.8px 0.8px 0 hsl(0, 0%, 75%), 2px 2px 0 hsl(0, 0%, 72%);
+
+      &:has(.choice-select__option:active) {
+        transition: box-shadow 180ms ease;
+        box-shadow: 0.8px 0.8px 0 hsl(0, 0%, 75%), 1.2px 1.2px 0 hsl(0, 0%, 72%);
+      }
     }
 
     .choice-select__option {
@@ -114,8 +117,13 @@
     }
   }
 
+  .choice-select__option:first-child {
+    border-radius: var(--border-radius) var(--border-radius) 0 0;
+  }
+
   .choice-select__option:last-child {
-    border-bottom: none;
+    border-radius: 0 0 var(--border-radius) var(--border-radius);
+    box-shadow: none;
   }
 
   .choice-select__option:hover {

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -89,9 +89,12 @@
   .choice-select[aria-expanded='false'] {
     transition: overflow 120ms allow-discrete ease-in;
 
-    .choice-select__option:has(.choice-select__radio:checked) {
+    .choice-select__option {
       box-shadow: none;
-      opacity: 1;
+
+      &:has(.choice-select__radio:checked) {
+        opacity: 1;
+      }
     }
   }
 

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -24,7 +24,7 @@
   .choice-select__list {
     position: relative;
     font-size: 13.3333px;
-    background: #eee;
+    background: transparent;
     height: calc(var(--choice-count) * var(--option-height));
     top: 0;
 
@@ -36,6 +36,23 @@
     border-radius: var(--border-radius);
     width: 100%;
     transition: var(--transition-select-list);
+  }
+
+  .choice-select__border {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: var(--option-height);
+
+    border-style: solid;
+    border-width: 1px 2px 2px 1px;
+    border-color: hsl(0, 0%, 75%) hsl(0, 0%, 72%) hsl(0, 0%, 72%) hsl(0, 0%, 75%);
+
+    border-radius: var(--border-radius);
+    pointer-events: none;
+
+    transition: top var(--transition-select-list-duration) ease-in-out, height
+      var(--transition-select-list-duration) ease-in-out;
   }
 
   .choice-select__option {
@@ -102,6 +119,10 @@
   .choice-select__list[aria-expanded='true'] {
     z-index: 1;
     clip-path: inset(0px round var(--border-radius)) !important;
+    .choice-select__border {
+      top: 0 !important;
+      height: calc(var(--choice-count) * var(--option-height)) ;
+    }
   }
 
   .choice-select__option:hover {
@@ -117,11 +138,14 @@
   }
 
   .choice-select__list:has(.choice-select__option:nth-of-type(1) .choice-select__radio:checked) {
-    top: calc(0 * var(--option-height));
+    top: 0;
     clip-path: inset(
       calc(0 * var(--option-height)) 0 calc((var(--choice-count) - 0 - 1) * var(--option-height)) 0 round
         var(--border-radius)
     );
+    .choice-select__border {
+      top: 0;
+    }
   }
   .choice-select__list:has(.choice-select__option:nth-of-type(2) .choice-select__radio:checked) {
     top: calc(-1 * var(--option-height));
@@ -129,6 +153,9 @@
       calc(1 * var(--option-height)) 0 calc((var(--choice-count) - 1 - 1) * var(--option-height)) 0 round
         var(--border-radius)
     );
+    .choice-select__border {
+      top: var(--option-height);
+    }
   }
   .choice-select__list:has(.choice-select__option:nth-of-type(3) .choice-select__radio:checked) {
     top: calc(-2 * var(--option-height));
@@ -136,6 +163,9 @@
       calc(2 * var(--option-height)) 0 calc((var(--choice-count) - 2 - 1) * var(--option-height)) 0 round
         var(--border-radius)
     );
+    .choice-select__border {
+      top: calc(2 * var(--option-height));
+    }
   }
   .choice-select__list:has(.choice-select__option:nth-of-type(4) .choice-select__radio:checked) {
     top: calc(-3 * var(--option-height));
@@ -143,6 +173,9 @@
       calc(3 * var(--option-height)) 0 calc((var(--choice-count) - 3 - 1) * var(--option-height)) 0 round
         var(--border-radius)
     );
+    .choice-select__border {
+      top: calc(3 * var(--option-height));
+    }
   }
   .choice-select__list:has(.choice-select__option:nth-of-type(5) .choice-select__radio:checked) {
     top: calc(-4 * var(--option-height));
@@ -150,6 +183,9 @@
       calc(4 * var(--option-height)) 0 calc((var(--choice-count) - 4 - 1) * var(--option-height)) 0 round
         var(--border-radius)
     );
+    .choice-select__border {
+      top: calc(4 * var(--option-height));
+    }
   }
   .choice-select__list:has(.choice-select__option:nth-of-type(6) .choice-select__radio:checked) {
     top: calc(-5 * var(--option-height));
@@ -157,6 +193,9 @@
       calc(5 * var(--option-height)) 0 calc((var(--choice-count) - 5 - 1) * var(--option-height)) 0 round
         var(--border-radius)
     );
+    .choice-select__border {
+      top: calc(5 * var(--option-height));
+    }
   }
   .choice-select__list:has(.choice-select__option:nth-of-type(7) .choice-select__radio:checked) {
     top: calc(-6 * var(--option-height));
@@ -164,6 +203,9 @@
       calc(6 * var(--option-height)) 0 calc((var(--choice-count) - 6 - 1) * var(--option-height)) 0 round
         var(--border-radius)
     );
+    .choice-select__border {
+      top: calc(6 * var(--option-height));
+    }
   }
 }
 

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -1,4 +1,4 @@
-.choice-group {
+.choice-group-container {
   position: relative;
 
   /* layout */
@@ -114,7 +114,9 @@
   .hidden {
     display: none !important;
   }
+}
 
+.choice-group {
   /* choice visibility logic */
   select:has(option:nth-of-type(1):not(:checked)) ~ .choice:nth-of-type(1),
   select:has(option:nth-of-type(2):not(:checked)) ~ .choice:nth-of-type(2),

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -87,6 +87,8 @@
   }
 
   .choice-select[aria-expanded='false'] {
+    transition: overflow 120ms allow-discrete ease-in;
+
     .choice-select__option:has(.choice-select__radio:checked) {
       box-shadow: none;
       opacity: 1;

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -8,9 +8,13 @@
   --transition-select-duration-2: 1500ms;
   --transition-select-duration-3: 1500ms;
   --transition-select: overflow var(--transition-select-duration-2) allow-discrete ease-in;
-  --transition-select-list-expand: top var(--transition-select-duration-3) cubic-bezier(0.2, 0.9, 0.2, 1), box-shadow var(--transition-select-duration-3) ease;
-  --transition-select-list-collapse: top var(--transition-select-duration-1) cubic-bezier(0.2, 0.9, 0.2, 1), box-shadow var(--transition-select-duration-1) ease;
-  --transition-select-option: background var(--transition-select-duration-1) ease, opacity var(--transition-select-duration-1) ease-out, box-shadow var(--transition-select-duration-1) ease-out, border-radius var(--transition-select-duration-1) ease-in-out;
+  --transition-select-list-expand: top var(--transition-select-duration-3) cubic-bezier(0.2, 0.9, 0.2, 1), box-shadow
+    var(--transition-select-duration-3) ease;
+  --transition-select-list-collapse: top var(--transition-select-duration-1) cubic-bezier(0.2, 0.9, 0.2, 1), box-shadow
+    var(--transition-select-duration-1) ease;
+  --transition-select-option: background var(--transition-select-duration-1) ease, opacity
+    var(--transition-select-duration-1) ease-out, box-shadow var(--transition-select-duration-1) ease-out, border-radius
+    var(--transition-select-duration-1) ease-in-out;
   --transition-select-icon: filter 500ms ease, opacity 500ms ease;
 
   .choice-group__selects {

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -49,6 +49,18 @@
     transition: background 120ms ease;
   }
 
+  .choice-select__radio {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
   .choice-select__option-content {
     display: inline-flex;
     align-items: center;
@@ -95,11 +107,11 @@
     background: #f5f5f5;
   }
 
-  .choice-select__option[aria-selected='true'] {
+  .choice-select__option:has(.choice-select__radio:checked) {
     background: #eee;
   }
 
-  .choice-select__option[aria-disabled='true'] {
+  .choice-select__option:has(.choice-select__radio:disabled) {
     color: #999;
     cursor: not-allowed;
     opacity: 0.8;

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -91,6 +91,7 @@
   .choice-select[aria-expanded='false'] {
     overflow: hidden;
     border-width: 1px 2px 2px 1px;
+    transition: overflow 0s 180ms allow-discrete, z-index 0s 180ms allow-discrete;
 
     .choice-select__option:has(.choice-select__radio:checked) {
       opacity: 1;

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -101,6 +101,9 @@
     .choice-select__border {
       transition: none;
     }
+    .choice-select__option {
+      transition: none;
+    }
   }
 
   .choice-select__option:not(:last-child) {

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -10,7 +10,7 @@
   --transition-select: overflow var(--transition-select-duration-2) allow-discrete ease-in;
   --transition-select-list-expand: top var(--transition-select-duration-3) cubic-bezier(0.2, 0.9, 0.2, 1), box-shadow var(--transition-select-duration-3) ease;
   --transition-select-list-collapse: top var(--transition-select-duration-1) cubic-bezier(0.2, 0.9, 0.2, 1), box-shadow var(--transition-select-duration-1) ease;
-  --transition-select-option: background var(--transition-select-duration-1) ease, opacity var(--transition-select-duration-1) ease-out, box-shadow var(--transition-select-duration-1) ease-out;
+  --transition-select-option: background var(--transition-select-duration-1) ease, opacity var(--transition-select-duration-1) ease-out, box-shadow var(--transition-select-duration-1) ease-out, border-radius var(--transition-select-duration-1) ease-in-out;
   --transition-select-icon: filter 500ms ease, opacity 500ms ease;
 
   .choice-group__selects {
@@ -104,6 +104,7 @@
 
       &:has(.choice-select__radio:checked) {
         opacity: 1;
+        border-radius: var(--border-radius);
       }
     }
   }

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -4,12 +4,11 @@
   /* layout */
   --top-position: 10px;
   --border-radius: 5px;
-  --transition-select-list-duration: 1000ms;
-  --transition-select-option-duration: 1000ms;
+  --transition-select-list-duration: 180ms;
+  --transition-select-option-duration: 120ms;
   --transition-select-list: top var(--transition-select-list-duration) cubic-bezier(0.2, 0.9, 0.2, 1), clip-path
     var(--transition-select-list-duration) ease-in-out;
-  --transition-select-option: background var(--transition-select-option-duration) ease, border-radius
-    var(--transition-select-option-duration) ease-in-out;
+  --transition-select-option: background var(--transition-select-option-duration) ease;
   --transition-select-icon: filter 500ms ease, opacity 500ms ease;
 
   .choice-group__selects {
@@ -51,8 +50,8 @@
     border-radius: var(--border-radius);
     pointer-events: none;
 
-    transition: top var(--transition-select-list-duration) ease-in-out, height
-      var(--transition-select-list-duration) ease-in-out;
+    transition: top var(--transition-select-list-duration) ease-in-out, height var(--transition-select-list-duration)
+      ease-in-out;
   }
 
   .choice-select__option {
@@ -94,26 +93,10 @@
     transition: var(--transition-select-icon);
   }
 
-  .choice-select__option:first-child {
-    border-top-left-radius: var(--border-radius);
-    border-top-right-radius: var(--border-radius);
-  }
-
-  .choice-select__option:last-child {
-    border-bottom-left-radius: var(--border-radius);
-    border-bottom-right-radius: var(--border-radius);
-  }
-
   .choice-select__list:hover .choice-select__option img,
   .choice-select__list[aria-expanded='true'] .choice-select__option img {
     filter: grayscale(0%);
     opacity: 1;
-  }
-
-  .choice-select__list[aria-expanded='false'] {
-    .choice-select__option:has(.choice-select__radio:checked) {
-      border-radius: var(--border-radius);
-    }
   }
 
   .choice-select__list[aria-expanded='true'] {
@@ -121,7 +104,7 @@
     clip-path: inset(0px round var(--border-radius)) !important;
     .choice-select__border {
       top: 0 !important;
-      height: calc(var(--choice-count) * var(--option-height)) ;
+      height: calc(var(--choice-count) * var(--option-height));
     }
   }
 

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -16,6 +16,7 @@
 
   .choice-select {
     background: #eee;
+    height: var(--option-height);
     font-size: 13.3333px;
 
     -webkit-user-select: none; /* Safari */
@@ -30,6 +31,7 @@
 
   .choice-select__list {
     position: relative;
+    top: 0;
     border-radius: 5px;
     border-color: var(--border-color);
     width: 100%;
@@ -39,6 +41,7 @@
 
   .choice-select__option {
     display: flex;
+    height: var(--option-height);
     white-space: nowrap;
     align-items: center;
     flex-wrap: nowrap;
@@ -113,6 +116,28 @@
 
   .hidden {
     display: none !important;
+  }
+
+  .choice-select:has(.choice-select__option:nth-of-type(1) .choice-select__radio:checked) .choice-select__list {
+    top: calc(0 * var(--option-height));
+  }
+  .choice-select:has(.choice-select__option:nth-of-type(2) .choice-select__radio:checked) .choice-select__list {
+    top: calc(-1 * var(--option-height));
+  }
+  .choice-select:has(.choice-select__option:nth-of-type(3) .choice-select__radio:checked) .choice-select__list {
+    top: calc(-2 * var(--option-height));
+  }
+  .choice-select:has(.choice-select__option:nth-of-type(4) .choice-select__radio:checked) .choice-select__list {
+    top: calc(-3 * var(--option-height));
+  }
+  .choice-select:has(.choice-select__option:nth-of-type(5) .choice-select__radio:checked) .choice-select__list {
+    top: calc(-4 * var(--option-height));
+  }
+  .choice-select:has(.choice-select__option:nth-of-type(6) .choice-select__radio:checked) .choice-select__list {
+    top: calc(-5 * var(--option-height));
+  }
+  .choice-select:has(.choice-select__option:nth-of-type(7) .choice-select__radio:checked) .choice-select__list {
+    top: calc(-6 * var(--option-height));
   }
 }
 

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -4,6 +4,10 @@
   /* layout */
   --top-position: 10px;
   --border-radius: 5px;
+  --transition-select: overflow 120ms allow-discrete ease-in;
+  --transition-select-list: top 180ms cubic-bezier(0.2, 0.9, 0.2, 1), box-shadow 180ms ease;
+  --transition-select-option: background 120ms ease, opacity 180ms ease-out, box-shadow 180ms ease-out;
+  --transition-select-icon: filter 500ms ease, opacity 500ms ease;
 
   .choice-group__selects {
     position: absolute;
@@ -35,7 +39,7 @@
     top: 0;
     border-radius: var(--border-radius);
     width: 100%;
-    transition: top 180ms cubic-bezier(0.2, 0.9, 0.2, 1), box-shadow 180ms ease;
+    transition: var(--transition-select-list);
   }
 
   .choice-select__option {
@@ -49,7 +53,7 @@
     box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.1);
     cursor: pointer;
     opacity: 0;
-    transition: background 120ms ease, opacity 180ms ease-out, box-shadow 180ms ease-out;
+    transition: var(--transition-select-option);
   }
 
   .choice-select__radio {
@@ -76,8 +80,7 @@
 
     filter: grayscale(100%);
     opacity: 0.8;
-    --transition: 500ms ease;
-    transition: filter var(--transition), opacity var(--transition);
+    transition: var(--transition-select-icon);
   }
 
   .choice-select:hover .choice-select__option img,
@@ -87,7 +90,7 @@
   }
 
   .choice-select[aria-expanded='false'] {
-    transition: overflow 120ms allow-discrete ease-in;
+    transition: var(--transition-select);
 
     .choice-select__option {
       box-shadow: none;

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -49,7 +49,9 @@
     padding: 0 6px;
     border-bottom: 1px solid rgba(0, 0, 0, 0.1);
     cursor: pointer;
-    transition: background 120ms ease;
+    opacity: 0;
+    transform: translateY(0.5px);
+    transition: background 120ms ease, opacity 180ms ease, transform 180ms ease;
   }
 
   .choice-select__radio {
@@ -89,6 +91,11 @@
   .choice-select[aria-expanded='false'] {
     overflow: hidden;
     border-width: 1px 2px 2px 1px;
+
+    .choice-select__option:has(.choice-select__radio:checked) {
+      opacity: 1;
+      transform: translateY(0);
+    }
   }
 
   .choice-select[aria-expanded='true'] {
@@ -99,6 +106,11 @@
     .choice-select__list {
       border-style: solid;
       border-width: 1px 2px 2px 1px;
+    }
+
+    .choice-select__option {
+      opacity: 1;
+      transform: translateY(0);
     }
   }
 

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -4,45 +4,36 @@
   /* layout */
   --top-position: 10px;
   --border-radius: 5px;
-  --transition-select-duration-1: 1000ms;
-  --transition-select-duration-2: 1000ms;
-  --transition-select: overflow var(--transition-select-duration-2) 100ms allow-discrete ease-in;
-  --transition-select-list: top var(--transition-select-duration-1) cubic-bezier(0.2, 0.9, 0.2, 1), box-shadow
-    var(--transition-select-duration-1) ease, clip-path var(--transition-select-duration-1) ease-in-out;
-  --transition-select-option: background var(--transition-select-duration-1) ease, opacity
-    var(--transition-select-duration-1) ease-out, box-shadow var(--transition-select-duration-1) ease-out, border-radius
-    var(--transition-select-duration-1) ease-in-out;
+  --transition-select-list-duration: 1000ms;
+  --transition-select-option-duration: 1000ms;
+  --transition-select-list: top var(--transition-select-list-duration) cubic-bezier(0.2, 0.9, 0.2, 1), clip-path
+    var(--transition-select-list-duration) ease-in-out;
+  --transition-select-option: background var(--transition-select-option-duration) ease, border-radius
+    var(--transition-select-option-duration) ease-in-out;
   --transition-select-icon: filter 500ms ease, opacity 500ms ease;
 
   .choice-group__selects {
     position: absolute;
     display: flex;
     flex-direction: row-reverse;
-    gap: 5px;
+    gap: 2px;
     top: var(--top-position);
-    right: 45px;
+    right: 42px;
   }
 
-  .choice-select {
-    background: #eee;
-    height: var(--option-height);
+  .choice-select__list {
+    position: relative;
     font-size: 13.3333px;
+    background: #eee;
+    height: calc(var(--choice-count) * var(--option-height));
+    top: 0;
 
     -webkit-user-select: none; /* Safari */
     -moz-user-select: none; /* Firefox */
     -ms-user-select: none; /* IE/Edge legacy */
     user-select: none; /* Standard */
 
-    border: none;
     border-radius: var(--border-radius);
-    box-shadow: 0.8px 0.8px 0px 1.8px hsl(0, 0%, 75%), 2px 2px 0px 1px hsl(0, 0%, 72%);
-  }
-
-  .choice-select__list {
-    position: relative;
-    top: 0;
-    border-radius: var(--border-radius);
-    box-shadow: 0.8px 0.8px 0px 1.8px hsl(0, 0%, 75%), 2px 2px 0px 1px hsl(0, 0%, 72%);
     width: 100%;
     transition: var(--transition-select-list);
   }
@@ -55,9 +46,7 @@
     flex-wrap: nowrap;
     background: #fff;
     padding: 0 6px;
-    box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.1);
     cursor: pointer;
-    opacity: 0;
     transition: var(--transition-select-option);
   }
 
@@ -88,58 +77,31 @@
     transition: var(--transition-select-icon);
   }
 
-  .choice-select:hover .choice-select__option img,
-  .choice-select[aria-expanded='true'] .choice-select__option img {
+  .choice-select__option:first-child {
+    border-top-left-radius: var(--border-radius);
+    border-top-right-radius: var(--border-radius);
+  }
+
+  .choice-select__option:last-child {
+    border-bottom-left-radius: var(--border-radius);
+    border-bottom-right-radius: var(--border-radius);
+  }
+
+  .choice-select__list:hover .choice-select__option img,
+  .choice-select__list[aria-expanded='true'] .choice-select__option img {
     filter: grayscale(0%);
     opacity: 1;
   }
 
-  .choice-select[aria-expanded='false'] {
-    .choice-select__option {
-      box-shadow: none;
-
-      &:has(.choice-select__radio:checked) {
-        opacity: 1;
-        border-radius: var(--border-radius);
-      }
+  .choice-select__list[aria-expanded='false'] {
+    .choice-select__option:has(.choice-select__radio:checked) {
+      border-radius: var(--border-radius);
     }
   }
 
-  .choice-select[aria-expanded='true'] {
+  .choice-select__list[aria-expanded='true'] {
     z-index: 1;
-
-    &:has(.choice-select__option:active) {
-      box-shadow: none;
-      .choice-select__option {
-        box-shadow: none;
-      }
-    }
-
-    .choice-select__list {
-      clip-path: inset(0px round var(--border-radius)) !important;
-      box-shadow: 0.8px 0.8px 0px 1.8px hsl(0, 0%, 72%), 2px 2px 0px 1px hsl(0, 0%, 66%);
-
-      &:has(.choice-select__option:active) {
-        box-shadow: 0.8px 0.8px 0px 1.8px hsl(0, 0%, 75%), 1.2px 1.2px 0px 1px hsl(0, 0%, 72%);
-      }
-    }
-
-    .choice-select__option {
-      opacity: 1;
-
-      &:active {
-        box-shadow: inset 1.2px 1.2px hsl(0, 0%, 66%), inset -0.8px -0.8px hsl(0, 0%, 72%) !important;
-      }
-    }
-  }
-
-  .choice-select__option:first-child {
-    border-radius: var(--border-radius) var(--border-radius) 0 0;
-  }
-
-  .choice-select__option:last-child {
-    border-radius: 0 0 var(--border-radius) var(--border-radius);
-    box-shadow: none;
+    clip-path: inset(0px round var(--border-radius)) !important;
   }
 
   .choice-select__option:hover {
@@ -154,33 +116,54 @@
     display: none !important;
   }
 
-  .choice-select:has(.choice-select__option:nth-of-type(1) .choice-select__radio:checked) .choice-select__list {
+  .choice-select__list:has(.choice-select__option:nth-of-type(1) .choice-select__radio:checked) {
     top: calc(0 * var(--option-height));
-    clip-path: inset(calc(0 * var(--option-height)) 0 calc( (var(--choice-count) - 0 - 1) * var(--option-height)) 0 round var(--border-radius));
+    clip-path: inset(
+      calc(0 * var(--option-height)) 0 calc((var(--choice-count) - 0 - 1) * var(--option-height)) 0 round
+        var(--border-radius)
+    );
   }
-  .choice-select:has(.choice-select__option:nth-of-type(2) .choice-select__radio:checked) .choice-select__list {
+  .choice-select__list:has(.choice-select__option:nth-of-type(2) .choice-select__radio:checked) {
     top: calc(-1 * var(--option-height));
-    clip-path: inset(calc(1 * var(--option-height)) 0 calc( (var(--choice-count) - 1 - 1) * var(--option-height)) 0 round var(--border-radius));
+    clip-path: inset(
+      calc(1 * var(--option-height)) 0 calc((var(--choice-count) - 1 - 1) * var(--option-height)) 0 round
+        var(--border-radius)
+    );
   }
-  .choice-select:has(.choice-select__option:nth-of-type(3) .choice-select__radio:checked) .choice-select__list {
+  .choice-select__list:has(.choice-select__option:nth-of-type(3) .choice-select__radio:checked) {
     top: calc(-2 * var(--option-height));
-    clip-path: inset(calc(2 * var(--option-height)) 0 calc( (var(--choice-count) - 2 - 1) * var(--option-height)) 0 round var(--border-radius));
+    clip-path: inset(
+      calc(2 * var(--option-height)) 0 calc((var(--choice-count) - 2 - 1) * var(--option-height)) 0 round
+        var(--border-radius)
+    );
   }
-  .choice-select:has(.choice-select__option:nth-of-type(4) .choice-select__radio:checked) .choice-select__list {
+  .choice-select__list:has(.choice-select__option:nth-of-type(4) .choice-select__radio:checked) {
     top: calc(-3 * var(--option-height));
-    clip-path: inset(calc(3 * var(--option-height)) 0 calc( (var(--choice-count) - 3 - 1) * var(--option-height)) 0 round var(--border-radius));
+    clip-path: inset(
+      calc(3 * var(--option-height)) 0 calc((var(--choice-count) - 3 - 1) * var(--option-height)) 0 round
+        var(--border-radius)
+    );
   }
-  .choice-select:has(.choice-select__option:nth-of-type(5) .choice-select__radio:checked) .choice-select__list {
+  .choice-select__list:has(.choice-select__option:nth-of-type(5) .choice-select__radio:checked) {
     top: calc(-4 * var(--option-height));
-    clip-path: inset(calc(4 * var(--option-height)) 0 calc( (var(--choice-count) - 4 - 1) * var(--option-height)) 0 round var(--border-radius));
+    clip-path: inset(
+      calc(4 * var(--option-height)) 0 calc((var(--choice-count) - 4 - 1) * var(--option-height)) 0 round
+        var(--border-radius)
+    );
   }
-  .choice-select:has(.choice-select__option:nth-of-type(6) .choice-select__radio:checked) .choice-select__list {
+  .choice-select__list:has(.choice-select__option:nth-of-type(6) .choice-select__radio:checked) {
     top: calc(-5 * var(--option-height));
-    clip-path: inset(calc(5 * var(--option-height)) 0 calc( (var(--choice-count) - 5 - 1) * var(--option-height)) 0 round var(--border-radius));
+    clip-path: inset(
+      calc(5 * var(--option-height)) 0 calc((var(--choice-count) - 5 - 1) * var(--option-height)) 0 round
+        var(--border-radius)
+    );
   }
-  .choice-select:has(.choice-select__option:nth-of-type(7) .choice-select__radio:checked) .choice-select__list {
+  .choice-select__list:has(.choice-select__option:nth-of-type(7) .choice-select__radio:checked) {
     top: calc(-6 * var(--option-height));
-    clip-path: inset(calc(6 * var(--option-height)) 0 calc( (var(--choice-count) - 6 - 1) * var(--option-height)) 0 round var(--border-radius));
+    clip-path: inset(
+      calc(6 * var(--option-height)) 0 calc((var(--choice-count) - 6 - 1) * var(--option-height)) 0 round
+        var(--border-radius)
+    );
   }
 }
 

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -4,9 +4,11 @@
   /* layout */
   --top-position: 10px;
   --border-radius: 5px;
-  --transition-select: overflow 120ms allow-discrete ease-in;
-  --transition-select-list: top 180ms cubic-bezier(0.2, 0.9, 0.2, 1), box-shadow 180ms ease;
-  --transition-select-option: background 120ms ease, opacity 180ms ease-out, box-shadow 180ms ease-out;
+  --transition-select-duration-1: 1800ms;
+  --transition-select-duration-2: 1800ms;
+  --transition-select: overflow var(--transition-select-duration-2) allow-discrete ease-in;
+  --transition-select-list: top var(--transition-select-duration-1) cubic-bezier(0.2, 0.9, 0.2, 1), box-shadow var(--transition-select-duration-1) ease;
+  --transition-select-option: background var(--transition-select-duration-2) ease, opacity var(--transition-select-duration-1) ease-out, box-shadow var(--transition-select-duration-1) ease-out;
   --transition-select-icon: filter 500ms ease, opacity 500ms ease;
 
   .choice-group__selects {

--- a/src/code-blocks/components/ChoiceGroup.tsx
+++ b/src/code-blocks/components/ChoiceGroup.tsx
@@ -48,7 +48,7 @@ function ChoiceGroup({ children, choiceGroup }: { children: React.ReactNode; cho
 
 const OPTION_HEIGHT = 25
 function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
-  const id = useId()
+  const radioId = useId()
   const choicesAll = usePageContext().config.docpress.choices
   const { name: groupName, emptyChoices, default: defaultChoice, hidden, parentChoiceGroup, isBuiltIn } = choiceGroup
   const [selectedChoice, setSelectedChoice] = useCurrentSelection(groupName, defaultChoice)
@@ -93,7 +93,7 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
             <input
               type="radio"
               className="choice-select__radio"
-              name={`radio-${id}`}
+              name={`radio-${radioId}`}
               value={choice}
               checked={selectedChoice === choice}
               readOnly

--- a/src/code-blocks/components/ChoiceGroup.tsx
+++ b/src/code-blocks/components/ChoiceGroup.tsx
@@ -53,6 +53,7 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
   const { name: groupName, emptyChoices, default: defaultChoice, hidden, parentChoiceGroup, isBuiltIn } = choiceGroup
   const [selectedChoice, setSelectedChoice] = useCurrentSelection(groupName, defaultChoice)
   const [expanded, setExpanded] = useState(false)
+  const [isHovered, setIsHovered] = useState(false)
   const [parentSelectedChoice] = useCurrentSelection(parentChoiceGroup?.name || '', parentChoiceGroup?.default || '')
   const setPrevPosition = useRestoreScroll([selectedChoice])
 
@@ -67,10 +68,20 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
       id={`choicesFor-${groupName}`}
       aria-expanded={expanded}
       role="radiogroup"
-      className={cls(['choice-select__list', (isHidden || isEmptyChoice(selectedChoice)) && 'hidden'])}
+      className={cls([
+        'choice-select__list',
+        (isHidden || isEmptyChoice(selectedChoice)) && 'hidden',
+        isHovered && 'hovered',
+      ])}
       style={{ '--option-height': `${OPTION_HEIGHT}px`, '--choice-count': filteredChoices.length }}
-      onMouseEnter={() => setExpanded(true)}
+      onMouseEnter={() => {
+        setExpanded(true)
+        setIsHovered(true)
+      }}
       onMouseLeave={() => setExpanded(false)}
+      onTransitionEnd={() => {
+        if (!expanded) setIsHovered(false)
+      }}
       onClick={() => {
         if (!expanded) next()
       }}

--- a/src/code-blocks/components/ChoiceGroup.tsx
+++ b/src/code-blocks/components/ChoiceGroup.tsx
@@ -86,7 +86,7 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
         >
           <input
             type="radio"
-            className="choice-select__radio"
+            className="choice-select__radio sr-only"
             name={`radio-${radioId}`}
             value={choice}
             checked={selectedChoice === choice}

--- a/src/code-blocks/components/ChoiceGroup.tsx
+++ b/src/code-blocks/components/ChoiceGroup.tsx
@@ -80,6 +80,7 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
         role="radiogroup"
         className="choice-select__list"
         style={{ top: rectTop, height: filteredChoices.length * OPTION_HEIGHT }}
+        data-choice-group={groupName}
       >
         {filteredChoices.map(({ name: choice, icon, iconStyle }) => (
           <label

--- a/src/code-blocks/components/ChoiceGroup.tsx
+++ b/src/code-blocks/components/ChoiceGroup.tsx
@@ -64,44 +64,39 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
 
   return (
     <div
-      aria-haspopup="listbox"
+      id={`choicesFor-${groupName}`}
       aria-expanded={expanded}
-      className={cls(['choice-select', (isHidden || isEmptyChoice(selectedChoice)) && 'hidden'])}
+      role="radiogroup"
+      className={cls(['choice-select__list', (isHidden || isEmptyChoice(selectedChoice)) && 'hidden'])}
       style={{ '--option-height': `${OPTION_HEIGHT}px`, '--choice-count': filteredChoices.length }}
       onMouseEnter={() => setExpanded(true)}
       onMouseLeave={() => setExpanded(false)}
       onClick={() => {
         if (!expanded) next()
       }}
+      data-choice-group={groupName}
     >
-      <div
-        id={`choicesFor-${groupName}`}
-        role="radiogroup"
-        className="choice-select__list"
-        data-choice-group={groupName}
-      >
-        {filteredChoices.map(({ name: choice, icon, iconStyle }) => (
-          <label
-            id={`choice-${choice}`}
-            key={choice}
-            className={`choice-select__option`}
-            onClick={(e) => handleOnClick(e, choice)}
-          >
-            <input
-              type="radio"
-              className="choice-select__radio"
-              name={`radio-${radioId}`}
-              value={choice}
-              checked={selectedChoice === choice}
-              readOnly
-            />
-            <span className="choice-select__option-content">
-              <img src={icon} alt="" aria-hidden="true" style={iconStyle} />
-              {choice}
-            </span>
-          </label>
-        ))}
-      </div>
+      {filteredChoices.map(({ name: choice, icon, iconStyle }) => (
+        <label
+          id={`choice-${choice}`}
+          key={choice}
+          className={`choice-select__option`}
+          onClick={(e) => handleOnClick(e, choice)}
+        >
+          <input
+            type="radio"
+            className="choice-select__radio"
+            name={`radio-${radioId}`}
+            value={choice}
+            checked={selectedChoice === choice}
+            readOnly
+          />
+          <span className="choice-select__option-content">
+            <img src={icon} alt="" aria-hidden="true" style={iconStyle} />
+            {choice}
+          </span>
+        </label>
+      ))}
     </div>
   )
 

--- a/src/code-blocks/components/ChoiceGroup.tsx
+++ b/src/code-blocks/components/ChoiceGroup.tsx
@@ -28,13 +28,13 @@ function ChoiceGroupContainer({
 }
 
 function ChoiceGroup({ children, choiceGroup }: { children: React.ReactNode; choiceGroup: TChoiceGroup }) {
-  const { name: groupName, choices, default: defaultChoice, lvl } = choiceGroup
+  const { name: groupName, choices, default: defaultChoice } = choiceGroup
   const [selectedChoice] = useCurrentSelection(groupName, defaultChoice)
 
   return (
-    <div data-choice-group={groupName} data-lvl={lvl} className="choice-group">
+    <div className="choice-group">
       {/* Hidden select used to control choice visibility via CSS */}
-      <select name={`choicesFor-${groupName}`} value={selectedChoice} hidden disabled>
+      <select data-choice-group={groupName} name={`choicesFor-${groupName}`} value={selectedChoice} hidden disabled>
         {choices.map(({ name: choice }) => (
           <option key={choice} value={choice}>
             {choice}

--- a/src/code-blocks/components/ChoiceGroup.tsx
+++ b/src/code-blocks/components/ChoiceGroup.tsx
@@ -61,15 +61,13 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
   const isEmptyChoice = (choice: string) => emptyChoices.includes(choice)
   const filteredChoices = choices.filter((choice) => !isEmptyChoice(choice.name))
   const selectedIndex = filteredChoices.findIndex((choice) => choice.name === selectedChoice)
-  const rectTop = -selectedIndex * OPTION_HEIGHT
 
   return (
     <div
-      id={`choicesFor-${groupName}`}
       aria-haspopup="listbox"
       aria-expanded={expanded}
       className={cls(['choice-select', (isHidden || isEmptyChoice(selectedChoice)) && 'hidden'])}
-      style={{ height: OPTION_HEIGHT }}
+      style={{ '--option-height': `${OPTION_HEIGHT}px` }}
       onMouseEnter={() => setExpanded(true)}
       onMouseLeave={() => setExpanded(false)}
       onClick={() => {
@@ -77,17 +75,17 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
       }}
     >
       <div
+        id={`choicesFor-${groupName}`}
         role="radiogroup"
         className="choice-select__list"
-        style={{ top: rectTop, height: filteredChoices.length * OPTION_HEIGHT }}
+        style={{ height: filteredChoices.length * OPTION_HEIGHT }}
         data-choice-group={groupName}
       >
         {filteredChoices.map(({ name: choice, icon, iconStyle }) => (
           <label
             id={`choice-${choice}`}
             key={choice}
-            className="choice-select__option"
-            style={{ height: OPTION_HEIGHT }}
+            className={`choice-select__option`}
             onClick={(e) => handleOnClick(e, choice)}
           >
             <input

--- a/src/code-blocks/components/ChoiceGroup.tsx
+++ b/src/code-blocks/components/ChoiceGroup.tsx
@@ -67,7 +67,7 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
       aria-haspopup="listbox"
       aria-expanded={expanded}
       className={cls(['choice-select', (isHidden || isEmptyChoice(selectedChoice)) && 'hidden'])}
-      style={{ '--option-height': `${OPTION_HEIGHT}px` }}
+      style={{ '--option-height': `${OPTION_HEIGHT}px`, '--choice-count': filteredChoices.length }}
       onMouseEnter={() => setExpanded(true)}
       onMouseLeave={() => setExpanded(false)}
       onClick={() => {
@@ -78,7 +78,6 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
         id={`choicesFor-${groupName}`}
         role="radiogroup"
         className="choice-select__list"
-        style={{ height: filteredChoices.length * OPTION_HEIGHT }}
         data-choice-group={groupName}
       >
         {filteredChoices.map(({ name: choice, icon, iconStyle }) => (

--- a/src/code-blocks/components/ChoiceGroup.tsx
+++ b/src/code-blocks/components/ChoiceGroup.tsx
@@ -1,32 +1,35 @@
-export { ChoiceGroup, CustomSelectsContainer }
+export { ChoiceGroup, ChoiceGroupContainer }
 
 import type { ChoiceGroup as TChoiceGroup, ChoiceGroupWithParent } from '../types.js'
-import React, { createContext, useContext, useId, useState } from 'react'
+import React, { useId, useState } from 'react'
 import { usePageContext } from '../../renderer/usePageContext.js'
 import { useCurrentSelection } from '../hooks/useCurrentSelection.js'
 import { useRestoreScroll } from '../hooks/useRestoreScroll.js'
 import { cls } from '../../utils/cls.js'
 import './ChoiceGroup.css'
 
-const CustomSelectsContainerContext = createContext<{ choiceGroupAll: ChoiceGroupWithParent[] } | undefined>(undefined)
-
-function useCustomSelectsContext() {
-  const ctx = useContext(CustomSelectsContainerContext)
-  if (!ctx) throw new Error('useCustomSelectsContext must be used inside provider')
-  return ctx
-}
-
-function CustomSelectsContainer({
+function ChoiceGroupContainer({
   children,
   choiceGroupAll,
 }: { children: React.ReactNode; choiceGroupAll: ChoiceGroupWithParent[] }) {
-  return <CustomSelectsContainerContext value={{ choiceGroupAll }}>{children}</CustomSelectsContainerContext>
+  const renderCustomSelect = choiceGroupAll.some((choiceGroup) => choiceGroup.lvl === 0 && !choiceGroup.hidden)
+  return (
+    <div className="choice-group-container">
+      {children}
+      {renderCustomSelect && (
+        <div className={`choice-group__selects`}>
+          {choiceGroupAll.map((choiceGroup) => (
+            <CustomSelect key={choiceGroup.name} choiceGroup={choiceGroup} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
 }
 
 function ChoiceGroup({ children, choiceGroup }: { children: React.ReactNode; choiceGroup: TChoiceGroup }) {
   const { name: groupName, choices, default: defaultChoice, lvl } = choiceGroup
   const [selectedChoice] = useCurrentSelection(groupName, defaultChoice)
-  const { choiceGroupAll } = useCustomSelectsContext()
 
   return (
     <div data-choice-group={groupName} data-lvl={lvl} className="choice-group">
@@ -39,13 +42,6 @@ function ChoiceGroup({ children, choiceGroup }: { children: React.ReactNode; cho
         ))}
       </select>
       {children}
-      {lvl === 0 && !choiceGroup.hidden && (
-        <div className={`choice-group__selects`}>
-          {choiceGroupAll.map((choiceGroup) => (
-            <CustomSelect key={choiceGroup.name} choiceGroup={choiceGroup} />
-          ))}
-        </div>
-      )}
     </div>
   )
 }

--- a/src/code-blocks/components/ChoiceGroup.tsx
+++ b/src/code-blocks/components/ChoiceGroup.tsx
@@ -1,7 +1,7 @@
 export { ChoiceGroup, CustomSelectsContainer }
 
 import type { ChoiceGroup as TChoiceGroup, ChoiceGroupWithParent } from '../types.js'
-import React, { createContext, useContext, useState } from 'react'
+import React, { createContext, useContext, useId, useState } from 'react'
 import { usePageContext } from '../../renderer/usePageContext.js'
 import { useCurrentSelection } from '../hooks/useCurrentSelection.js'
 import { useRestoreScroll } from '../hooks/useRestoreScroll.js'
@@ -52,6 +52,7 @@ function ChoiceGroup({ children, choiceGroup }: { children: React.ReactNode; cho
 
 const OPTION_HEIGHT = 25
 function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
+  const id = useId()
   const choicesAll = usePageContext().config.docpress.choices
   const { name: groupName, emptyChoices, default: defaultChoice, hidden, parentChoiceGroup, isBuiltIn } = choiceGroup
   const [selectedChoice, setSelectedChoice] = useCurrentSelection(groupName, defaultChoice)
@@ -80,26 +81,31 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
       }}
     >
       <div
-        aria-activedescendant={`choice-${selectedChoice}`}
-        role="listbox"
+        role="radiogroup"
         className="choice-select__list"
         style={{ top: rectTop, height: filteredChoices.length * OPTION_HEIGHT }}
       >
-        {filteredChoices.map(({ name: choice, icon, iconStyle }, i) => (
-          <div
+        {filteredChoices.map(({ name: choice, icon, iconStyle }) => (
+          <label
             id={`choice-${choice}`}
             key={choice}
-            aria-selected={i === selectedIndex}
-            role="option"
             className="choice-select__option"
             style={{ height: OPTION_HEIGHT }}
             onClick={(e) => handleOnClick(e, choice)}
           >
+            <input
+              type="radio"
+              className="choice-select__radio"
+              name={`radio-${id}`}
+              value={choice}
+              checked={selectedChoice === choice}
+              readOnly
+            />
             <span className="choice-select__option-content">
               <img src={icon} alt="" aria-hidden="true" style={iconStyle} />
               {choice}
             </span>
-          </div>
+          </label>
         ))}
       </div>
     </div>
@@ -109,11 +115,12 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
     const nextIndex = (selectedIndex + 1) % filteredChoices.length
     setSelectedChoice(filteredChoices[nextIndex]!.name)
   }
-  function handleOnClick(e: React.MouseEvent<HTMLDivElement, MouseEvent>, choice: string) {
-    e.stopPropagation()
+  function handleOnClick(e: React.MouseEvent<HTMLLabelElement, MouseEvent>, choice: string) {
+    e.preventDefault()
     const el = e.currentTarget
     setPrevPosition(el)
-    if (el.getAttribute('aria-selected') === 'true') {
+    const isSame = selectedChoice === choice
+    if (isSame) {
       next()
     } else {
       setSelectedChoice(choice)

--- a/src/code-blocks/components/ChoiceGroup.tsx
+++ b/src/code-blocks/components/ChoiceGroup.tsx
@@ -76,6 +76,7 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
       }}
       data-choice-group={groupName}
     >
+      <div className="choice-select__border" />
       {filteredChoices.map(({ name: choice, icon, iconStyle }) => (
         <label
           id={`choice-${choice}`}

--- a/src/code-blocks/components/Tabs.css
+++ b/src/code-blocks/components/Tabs.css
@@ -29,7 +29,7 @@
 .choice-tabs__tab-content {
   display: inline-flex;
   align-items: center;
-  gap: 2px;
+  gap: 6px;
 }
 
 .choice-tabs__tab img {

--- a/src/code-blocks/components/Tabs.css
+++ b/src/code-blocks/components/Tabs.css
@@ -2,16 +2,9 @@
   -webkit-tap-highlight-color: transparent;
 
   /* tablist style logic */
-  select:has(option:nth-of-type(1):checked) ~ ul[role='tablist'] li:nth-of-type(1),
-  select:has(option:nth-of-type(2):checked) ~ ul[role='tablist'] li:nth-of-type(2),
-  select:has(option:nth-of-type(3):checked) ~ ul[role='tablist'] li:nth-of-type(3),
-  select:has(option:nth-of-type(4):checked) ~ ul[role='tablist'] li:nth-of-type(4),
-  select:has(option:nth-of-type(5):checked) ~ ul[role='tablist'] li:nth-of-type(5),
-  select:has(option:nth-of-type(6):checked) ~ ul[role='tablist'] li:nth-of-type(6),
-  select:has(option:nth-of-type(7):checked) ~ ul[role='tablist'] li:nth-of-type(7) {
+  .choice-tabs__tab:has(.choice-tabs__radio:checked) {
     border-bottom: 2px solid #aaa;
     color: var(--color-text);
-    font-weight: 600;
   }
 }
 
@@ -31,6 +24,18 @@
   font-weight: 500;
   /* lighten --color-text by 20% */
   color: color-mix(in srgb, var(--color-text) 80%, white 20%);
+}
+
+.choice-tabs__radio {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .choice-tabs__tab-content {

--- a/src/code-blocks/components/Tabs.css
+++ b/src/code-blocks/components/Tabs.css
@@ -26,18 +26,6 @@
   color: color-mix(in srgb, var(--color-text) 80%, white 20%);
 }
 
-.choice-tabs__radio {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
 .choice-tabs__tab-content {
   display: inline-flex;
   align-items: center;

--- a/src/code-blocks/components/Tabs.tsx
+++ b/src/code-blocks/components/Tabs.tsx
@@ -17,80 +17,30 @@ function Tabs({ choice, hide = [] }: { choice: string; hide: string[] }) {
   const [selectedChoice, setSelectedChoice] = useCurrentSelection(groupName, defaultChoice)
   const setPrevPosition = useRestoreScroll([selectedChoice])
   const isHidden = (choice: string) => hide.includes(choice)
-  const filteredChoices = choices.filter((choice) => !isHidden(choice.name))
-  const selectedIndex = filteredChoices.findIndex((choice) => choice.name === selectedChoice)
 
   return (
     <div className="choice-tabs" data-choice-group={groupName}>
-      {/* Hidden select used to control tablist styling via CSS. */}
-      <select name={`choicesFor-${groupName}`} value={selectedChoice} hidden disabled>
-        {choices.map(({ name: choice }) => (
-          <option key={choice} value={choice}>
-            {choice}
-          </option>
-        ))}
-      </select>
-      <ul id={`choicesFor-${groupName}`} className="choice-tabs__tab-list" role="tablist">
-        {choices.map(({ name: choice, icon, iconStyle }, i) => (
-          <li
-            key={choice}
-            id={`tab-${choice}`}
-            style={{ display: isHidden(choice) ? 'none' : undefined }}
-            className="choice-tabs__tab"
-            role="tab"
-            aria-selected={i === selectedIndex}
-            tabIndex={i === selectedIndex ? 0 : -1}
-            onClick={(e) => handleOnClick(e, choice)}
-            onKeyDown={handleOnKeyDown}
-          >
+      <div className="choice-tabs__tab-list" role="radiogroup">
+        {choices.map(({ name: choice, icon, iconStyle }) => (
+          <label key={choice} className="choice-tabs__tab" style={{ display: isHidden(choice) ? 'none' : undefined }}>
+            <input
+              className="choice-tabs__radio"
+              type="radio"
+              name={`choicesFor-${groupName}`}
+              value={choice}
+              checked={selectedChoice === choice}
+              onChange={(e) => {
+                setPrevPosition(e.currentTarget)
+                setSelectedChoice(choice)
+              }}
+            />
             <span className="choice-tabs__tab-content">
               <img src={icon} alt="" aria-hidden="true" style={iconStyle} />
               {choice}
             </span>
-          </li>
+          </label>
         ))}
-      </ul>
+      </div>
     </div>
   )
-
-  function handleOnClick(e: React.MouseEvent<HTMLLIElement, MouseEvent>, choice: string) {
-    setPrevPosition(e.currentTarget)
-    setSelectedChoice(choice)
-  }
-
-  function handleOnKeyDown(e: React.KeyboardEvent<HTMLLIElement>) {
-    const el = e.currentTarget
-    let nextIndex = selectedIndex
-
-    switch (e.key) {
-      case 'ArrowRight':
-        nextIndex = (selectedIndex + 1) % filteredChoices.length
-        break
-      case 'ArrowLeft':
-        nextIndex = (selectedIndex - 1 + filteredChoices.length) % filteredChoices.length
-        break
-      case 'Home':
-        nextIndex = 0
-        break
-      case 'End':
-        nextIndex = filteredChoices.length - 1
-        break
-      default:
-        return
-    }
-
-    e.preventDefault()
-    setPrevPosition(el)
-    const nextChoice = filteredChoices[nextIndex]!
-    setSelectedChoice(nextChoice.name)
-    const tabEl = el.parentElement?.parentElement as HTMLDivElement
-
-    if (!isInViewport(tabEl)) tabEl.scrollIntoView({ block: 'start', behavior: 'smooth' })
-    el.focus()
-  }
-}
-
-function isInViewport(el: Element) {
-  const rect = el.getBoundingClientRect()
-  return rect.top >= 0 && rect.left >= 0 && rect.bottom <= window.innerHeight && rect.right <= window.innerWidth
 }

--- a/src/code-blocks/components/Tabs.tsx
+++ b/src/code-blocks/components/Tabs.tsx
@@ -19,8 +19,13 @@ function Tabs({ choice, hide = [] }: { choice: string; hide: string[] }) {
   const isHidden = (choice: string) => hide.includes(choice)
 
   return (
-    <div className="choice-tabs" data-choice-group={groupName}>
-      <div id={`choicesFor-${groupName}`} className="choice-tabs__tab-list" role="radiogroup">
+    <div className="choice-tabs">
+      <div
+        id={`choicesFor-${groupName}`}
+        className="choice-tabs__tab-list"
+        role="radiogroup"
+        data-choice-group={groupName}
+      >
         {choices.map(({ name: choice, icon, iconStyle }) => (
           <label key={choice} className="choice-tabs__tab" style={{ display: isHidden(choice) ? 'none' : undefined }}>
             <input

--- a/src/code-blocks/components/Tabs.tsx
+++ b/src/code-blocks/components/Tabs.tsx
@@ -1,6 +1,6 @@
 export { Tabs }
 
-import React from 'react'
+import React, { useId } from 'react'
 import { useCurrentSelection } from '../hooks/useCurrentSelection.js'
 import { useRestoreScroll } from '../hooks/useRestoreScroll.js'
 import { usePageContext } from '../../renderer/usePageContext.js'
@@ -12,21 +12,21 @@ function Tabs({ choice, hide = [] }: { choice: string; hide: string[] }) {
   const pageContext = usePageContext()
   const choicesAll = pageContext.config.docpress.choices
   assertUsage(choicesAll && choicesAll[groupName], `${groupName} is unknown`)
-
   const { choices, default: defaultChoice } = choicesAll[groupName]
   const [selectedChoice, setSelectedChoice] = useCurrentSelection(groupName, defaultChoice)
+  const id = useId()
   const setPrevPosition = useRestoreScroll([selectedChoice])
   const isHidden = (choice: string) => hide.includes(choice)
 
   return (
     <div className="choice-tabs" data-choice-group={groupName}>
-      <div className="choice-tabs__tab-list" role="radiogroup">
+      <div id={`choicesFor-${groupName}`} className="choice-tabs__tab-list" role="radiogroup">
         {choices.map(({ name: choice, icon, iconStyle }) => (
           <label key={choice} className="choice-tabs__tab" style={{ display: isHidden(choice) ? 'none' : undefined }}>
             <input
               className="choice-tabs__radio"
               type="radio"
-              name={`choicesFor-${groupName}`}
+              name={`radio-${id}`}
               value={choice}
               checked={selectedChoice === choice}
               onChange={(e) => {

--- a/src/code-blocks/components/Tabs.tsx
+++ b/src/code-blocks/components/Tabs.tsx
@@ -8,13 +8,13 @@ import { assertUsage } from '../../utils/assert.js'
 import './Tabs.css'
 
 function Tabs({ choice, hide = [] }: { choice: string; hide: string[] }) {
+  const radioId = useId()
   const groupName = choice
   const pageContext = usePageContext()
   const choicesAll = pageContext.config.docpress.choices
   assertUsage(choicesAll && choicesAll[groupName], `${groupName} is unknown`)
   const { choices, default: defaultChoice } = choicesAll[groupName]
   const [selectedChoice, setSelectedChoice] = useCurrentSelection(groupName, defaultChoice)
-  const id = useId()
   const setPrevPosition = useRestoreScroll([selectedChoice])
   const isHidden = (choice: string) => hide.includes(choice)
 
@@ -31,7 +31,7 @@ function Tabs({ choice, hide = [] }: { choice: string; hide: string[] }) {
             <input
               className="choice-tabs__radio"
               type="radio"
-              name={`radio-${id}`}
+              name={`radio-${radioId}`}
               value={choice}
               checked={selectedChoice === choice}
               onChange={(e) => {

--- a/src/code-blocks/components/Tabs.tsx
+++ b/src/code-blocks/components/Tabs.tsx
@@ -29,7 +29,7 @@ function Tabs({ choice, hide = [] }: { choice: string; hide: string[] }) {
         {choices.map(({ name: choice, icon, iconStyle }) => (
           <label key={choice} className="choice-tabs__tab" style={{ display: isHidden(choice) ? 'none' : undefined }}>
             <input
-              className="choice-tabs__radio"
+              className="choice-tabs__radio sr-only"
               type="radio"
               name={`radio-${radioId}`}
               value={choice}

--- a/src/code-blocks/hooks/useCurrentSelection.ts
+++ b/src/code-blocks/hooks/useCurrentSelection.ts
@@ -19,25 +19,28 @@ function useCurrentSelection(choiceGroupName: string, defaultValue: string) {
 // WARNING: We cannot use `keyPrefix` here: closures don't work because we serialize the function.
 const initializeChoiceGroup_SSR = `initializeChoiceGroup();${initializeChoiceGroup.toString()};`
 function initializeChoiceGroup() {
-  const groupsElements = document.querySelectorAll<HTMLDivElement>('[data-choice-group]')
+  const groupsElements = [
+    ...document.querySelectorAll('select[data-choice-group]'),
+    ...document.querySelectorAll('div[data-choice-group]'),
+  ]
   for (const groupEl of groupsElements) {
-    const choiceGroupName = groupEl.dataset.choiceGroup
+    const choiceGroupName = groupEl.getAttribute('data-choice-group')
     if (!choiceGroupName) continue
     const storageKey = `docpress:choice:${choiceGroupName}`
     const selectedChoice = localStorage.getItem(storageKey)
     if (!selectedChoice) continue
-    const selectEl = groupEl.querySelector<HTMLSelectElement>(`select[name="choicesFor-${choiceGroupName}"]`)
-    if (selectEl) {
-      const optionExists = [...selectEl.options].some((opt) => opt.value === selectedChoice)
-      if (!optionExists) localStorage.removeItem(storageKey)
-      else selectEl.value = selectedChoice
-    } else {
-      const radiosElements = [...groupEl.querySelectorAll<HTMLInputElement>(`input[type="radio"]`)]
-      if (radiosElements.length > 0) {
-        const radio = radiosElements.find((radio) => radio.value === selectedChoice)
-        if (!radio) localStorage.removeItem(storageKey)
-        else radio.checked = true
-      }
+    switch (groupEl.tagName) {
+      case 'SELECT':
+        const selectEl = groupEl as HTMLSelectElement
+        const optionExists = [...selectEl.options].some((opt) => opt.value === selectedChoice)
+        if (!optionExists) localStorage.removeItem(storageKey)
+        else selectEl.value = selectedChoice
+        break
+      case 'DIV':
+        const radioEl = groupEl.querySelector<HTMLInputElement>(`input[type="radio"][value="${selectedChoice}"]`)
+        if (radioEl) radioEl.checked = true
+      default:
+        break
     }
   }
 }

--- a/src/code-blocks/hooks/useCurrentSelection.ts
+++ b/src/code-blocks/hooks/useCurrentSelection.ts
@@ -21,16 +21,22 @@ const initializeChoiceGroup_SSR = `initializeChoiceGroup();${initializeChoiceGro
 function initializeChoiceGroup() {
   const groupsElements = document.querySelectorAll<HTMLDivElement>('[data-choice-group]')
   for (const groupEl of groupsElements) {
-    const choiceGroupName = groupEl.getAttribute('data-choice-group')!
+    const choiceGroupName = groupEl.dataset.choiceGroup
+    if (!choiceGroupName) continue
     const storageKey = `docpress:choice:${choiceGroupName}`
     const selectedChoice = localStorage.getItem(storageKey)
-    if (selectedChoice) {
-      const selectEl = groupEl.querySelector<HTMLSelectElement>(`select[name="choicesFor-${choiceGroupName}"]`)!
-      const selectedIndex = [...selectEl.options].findIndex((option) => option.value === selectedChoice)
-      if (selectedIndex === -1) {
-        localStorage.removeItem(storageKey)
-      } else {
-        selectEl.value = selectedChoice
+    if (!selectedChoice) continue
+    const selectEl = groupEl.querySelector<HTMLSelectElement>(`select[name="choicesFor-${choiceGroupName}"]`)
+    if (selectEl) {
+      const optionExists = [...selectEl.options].some((opt) => opt.value === selectedChoice)
+      if (!optionExists) localStorage.removeItem(storageKey)
+      else selectEl.value = selectedChoice
+    } else {
+      const radiosElements = [...groupEl.querySelectorAll<HTMLInputElement>(`input[type="radio"]`)]
+      if (radiosElements.length > 0) {
+        const radio = radiosElements.find((radio) => radio.value === selectedChoice)
+        if (!radio) localStorage.removeItem(storageKey)
+        else radio.checked = true
       }
     }
   }

--- a/src/code-blocks/hooks/useMDXComponents.tsx
+++ b/src/code-blocks/hooks/useMDXComponents.tsx
@@ -3,12 +3,12 @@ export { useMDXComponents }
 import React from 'react'
 import type { UseMdxComponents } from '@mdx-js/mdx'
 import { Pre } from '../components/Pre.js'
-import { ChoiceGroup, CustomSelectsContainer } from '../components/ChoiceGroup.js'
+import { ChoiceGroup, ChoiceGroupContainer } from '../components/ChoiceGroup.js'
 
 const useMDXComponents: UseMdxComponents = () => {
   return {
     ChoiceGroup,
-    CustomSelectsContainer,
+    ChoiceGroupContainer,
     pre: (props) => <Pre {...props} />,
   }
 }

--- a/src/code-blocks/remarkChoiceGroup.ts
+++ b/src/code-blocks/remarkChoiceGroup.ts
@@ -83,7 +83,7 @@ const remarkChoiceGroup: Plugin<[], Root> = (): Transformer<Root> => {
     remarkPkgManager.call(this)(tree, file)
 
     visit(tree, 'mdxJsxFlowElement', (node) => {
-      if (node.name !== 'CustomSelectsContainer') return 'skip'
+      if (node.name !== 'ChoiceGroupContainer') return 'skip'
 
       const choiceGroupAll: ChoiceGroupWithParent[] = []
 

--- a/src/code-blocks/utils/generateChoiceGroupCode.ts
+++ b/src/code-blocks/utils/generateChoiceGroupCode.ts
@@ -123,7 +123,7 @@ function generateChoiceGroupCode(choiceNodes: ChoiceNode[], parent: Parent, hide
   if (lvl === 0) {
     return {
       type: 'mdxJsxFlowElement',
-      name: 'CustomSelectsContainer',
+      name: 'ChoiceGroupContainer',
       attributes: [],
       children: [choiceGroupNode],
     }

--- a/src/css/button.css
+++ b/src/css/button.css
@@ -12,14 +12,18 @@ button,
   border-radius: 5px;
   border: none;
 
-  box-shadow: 0.8px 0.8px 0 hsl(0, 0%, 75%), 2px 2px 0 hsl(0, 0%, 72%);
+  box-shadow: 0.8px 0.8px 0px 1.8px hsl(0, 0%, 75%), 2px 2px 0px 1px hsl(0, 0%, 72%);
 
   &:hover {
-    box-shadow: 0.8px 0.8px 0 hsl(0, 0%, 72%), 2px 2px 0 hsl(0, 0%, 66%);
+    box-shadow: 0.8px 0.8px 0px 1.8px hsl(0, 0%, 72%), 2px 2px 0px 1px hsl(0, 0%, 66%);
   }
 
   &:active {
-    box-shadow: inset 1.2px 1.2px 0 hsl(0, 0%, 66%), inset -0.8px -0.8px 0 hsl(0, 0%, 72%);
+    box-shadow:
+      inset 1.2px 1.2px 0 hsl(0, 0%, 66%),
+      inset -0.8px -0.8px 0 hsl(0, 0%, 72%),
+      0.8px 0.8px 0px 1.8px hsl(0, 0%, 75%),
+      1.2px 1.2px 0px 1px hsl(0, 0%, 72%);
   }
 
   &:disabled {

--- a/src/css/button.css
+++ b/src/css/button.css
@@ -10,21 +10,19 @@ button,
 .raised {
   cursor: pointer;
   border-radius: 5px;
-  border-style: solid;
-  border-width: 1px 2px 2px 1px;
-  border-color: hsl(0, 0%, 75%) hsl(0, 0%, 72%) hsl(0, 0%, 72%) hsl(0, 0%, 75%);
+  border: none;
+
+  box-shadow: 0.8px 0.8px 0 hsl(0, 0%, 75%), 2px 2px 0 hsl(0, 0%, 72%);
 
   &:hover {
-    border-color: hsl(0, 0%, 72%) hsl(0, 0%, 66%) hsl(0, 0%, 66%) hsl(0, 0%, 72%);
+    box-shadow: 0.8px 0.8px 0 hsl(0, 0%, 72%), 2px 2px 0 hsl(0, 0%, 66%);
   }
 
   &:active {
-    border-width: 2px 1px 1px 2px;
-    border-color: hsl(0, 0%, 66%) hsl(0, 0%, 72%) hsl(0, 0%, 72%) hsl(0, 0%, 66%);
+    box-shadow: inset 1.2px 1.2px 0 hsl(0, 0%, 66%), inset -0.8px -0.8px 0 hsl(0, 0%, 72%);
   }
 
   &:disabled {
-    border-width: 1px;
-    border-color: hsl(0, 0%, 72%);
+    box-shadow: inset 0 0 0 1px hsl(0, 0%, 72%);
   }
 }

--- a/src/css/button.css
+++ b/src/css/button.css
@@ -10,23 +10,21 @@ button,
 .raised {
   cursor: pointer;
   border-radius: 5px;
-  border: none;
-
-  box-shadow: 0.8px 0.8px 0px 1.8px hsl(0, 0%, 75%), 2px 2px 0px 1px hsl(0, 0%, 72%);
+  border-style: solid;
+  border-width: 1px 2px 2px 1px;
+  border-color: hsl(0, 0%, 75%) hsl(0, 0%, 72%) hsl(0, 0%, 72%) hsl(0, 0%, 75%);
 
   &:hover {
-    box-shadow: 0.8px 0.8px 0px 1.8px hsl(0, 0%, 72%), 2px 2px 0px 1px hsl(0, 0%, 66%);
+    border-color: hsl(0, 0%, 72%) hsl(0, 0%, 66%) hsl(0, 0%, 66%) hsl(0, 0%, 72%);
   }
 
   &:active {
-    box-shadow:
-      inset 1.2px 1.2px 0 hsl(0, 0%, 66%),
-      inset -0.8px -0.8px 0 hsl(0, 0%, 72%),
-      0.8px 0.8px 0px 1.8px hsl(0, 0%, 75%),
-      1.2px 1.2px 0px 1px hsl(0, 0%, 72%);
+    border-width: 2px 1px 1px 2px;
+    border-color: hsl(0, 0%, 66%) hsl(0, 0%, 72%) hsl(0, 0%, 72%) hsl(0, 0%, 66%);
   }
 
   &:disabled {
-    box-shadow: inset 0 0 0 1px hsl(0, 0%, 72%);
+    border-width: 1px;
+    border-color: hsl(0, 0%, 72%);
   }
 }

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -8,3 +8,4 @@
 @import './table.css';
 @import './tooltip.css';
 @import '@docsearch/css/dist/style.css';
+@import './sr-only.css';

--- a/src/css/sr-only.css
+++ b/src/css/sr-only.css
@@ -1,0 +1,11 @@
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
closes #158, #165

- Refactor `CustomSelect` and `Tabs` components to use radio inputs.
- Lift `CustomSelect` rendering from `ChoiceGroup` into `ChoiceGroupContainer` (renamed from `CustomSelectsContainer`).
- Refactor `initializeChoiceGroup()` to restore state for both select and radio inputs.
- Remove visual flicker in custom select dropdowns.
- Animate option visibility/opacity transitions for dropdown expand/collapse.
- Update the tests.