### PR TITLE
Add config.headHtml to inject markup into <head>

### DIFF
--- a/src/renderer/onRenderHtml.tsx
+++ b/src/renderer/onRenderHtml.tsx
@@ -30,11 +30,16 @@ async function onRenderHtml(pageContext: PageContextServer): Promise<any> {
         <meta name="viewport" content="width=device-width,initial-scale=1">
         ${getOpenGraphTags(pageContext.urlPathname, documentTitle, pageContext.globalContext.config.docpress)}
         ${getAlgoliaTags(pageContext)}
+        ${getHeadHtml(pageContext.globalContext.config.docpress)}
       </head>
       <body>
         <div id="page-view">${dangerouslySkipEscape(pageHtml)}</div>
       </body>
     </html>`
+}
+
+function getHeadHtml(config: Config) {
+  return config.headHtml ? dangerouslySkipEscape(config.headHtml) : ''
 }
 
 function getAlgoliaTags(pageContext: PageContextServer) {

--- a/src/types/Config.ts
+++ b/src/types/Config.ts
@@ -18,6 +18,18 @@ type Config = {
       }
   banner?: string
 
+  /**
+   * Raw HTML injected at the end of `<head>` on every page.
+   *
+   * Use for a small inline `<script>`/`<style>` that must run before first
+   * paint — e.g. a no-flash theme script that reads a cookie and applies the
+   * palette before the page renders (relevant for prerendered/static pages,
+   * where there is no request to read the cookie from at render time).
+   *
+   * Emitted verbatim (not escaped), so only pass trusted, self-authored markup.
+   */
+  headHtml?: string
+
   github: string
   discord?: string
   twitter?: string


### PR DESCRIPTION
New optional config field `headHtml?: string`. It emits raw HTML at the end of `<head>` on every page.

Why: lets a site drop a small inline `<script>`/`<style>` that runs before first paint. My use case is a no-flash theme switcher (vike-data#333): read the chosen theme from a cookie and apply the palette before the page renders, which also fixes prerendered pages, where there is no request to read the cookie from at render time. Today DocPress fully owns onRenderHtml and there is no seam for this.

Change is tiny: the field on the Config type, and one line in onRenderHtml that injects it via dangerouslySkipEscape before `</head>`. Verbatim output, so it is documented as trusted-markup only. No effect when unset.

Open to a different name if you prefer (Head, injectHead, etc.).