### PR TITLE
Tokenize typography via --font-* CSS variables

### DIFF
--- a/src/ExternalLinks.tsx
+++ b/src/ExternalLinks.tsx
@@ -63,7 +63,7 @@ function ChangelogButton() {
         className="button"
         style={{
           background: '#ffffff4f',
-          fontFamily: 'monospace',
+          fontFamily: 'var(--font-mono, monospace)',
           letterSpacing: -1,
           display: 'flex',
           alignItems: 'center',

--- a/src/code-blocks/components/Pre.css
+++ b/src/code-blocks/components/Pre.css
@@ -5,6 +5,7 @@ pre > code {
   */
   background: rgba(0, 0, 0, 0.043137255);
   font-size: 1em;
+  font-family: var(--font-mono, monospace);
 }
 
 /* Copy button */

--- a/src/css/code.css
+++ b/src/css/code.css
@@ -10,4 +10,5 @@ code {
   border-radius: 4px;
   background: rgba(0, 0, 0, 0.063137255);
   font-size: 1.1em;
+  font-family: var(--font-mono, monospace);
 }

--- a/src/css/font.css
+++ b/src/css/font.css
@@ -1,7 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-sans, 'Inter', sans-serif);
 }
 button {
   font-family: inherit;

--- a/src/css/tooltip.css
+++ b/src/css/tooltip.css
@@ -13,7 +13,7 @@
     opacity: 0;
     transition: opacity 0.3s ease-in-out;
     pointer-events: none;
-    font-family: monospace;
+    font-family: var(--font-mono, monospace);
     font-size: 12px;
     content: attr(aria-label);
     position: absolute;


### PR DESCRIPTION
Follows #171, for fonts. The shell now reads:

- `var(--font-sans, 'Inter', sans-serif)` for body text
- `var(--font-mono, monospace)` for code (inline + blocks), the tooltip, and the external-link snippets

Every consumer keeps its original literal as the fallback, so an unthemed site (vike.dev) is byte-identical. A site sets a font by declaring `--font-sans` / `--font-mono` on `:root` or `body` - the same seam vike-themes already emits, so the docpress-themes example can theme fonts with no extra glue.

Same quick-win, CSS-var direction we agreed on in #173. Type scale (heading sizes etc.) left for later. 5-line diff, tsc clean.