### PR TITLE
fix: keep the top nav visible on doc pages (#175)

### DIFF
--- a/demo/testRun.ts
+++ b/demo/testRun.ts
@@ -268,7 +268,9 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
   })
 
   test('client-side navigation', async () => {
-    await page.click('#nav-left a[href="/"]')
+    // The logo lives in the top nav now (the left-sidebar nav head is hidden on
+    // desktop since #175), so click that one to navigate home client-side.
+    await page.click('.nav-head:not(.is-nav-left) a[href="/"]')
     await autoRetry(
       async () => {
         await testLandingPageClient()

--- a/demo/testRun.ts
+++ b/demo/testRun.ts
@@ -268,8 +268,7 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
   })
 
   test('client-side navigation', async () => {
-    // The logo lives in the top nav now (the left-sidebar nav head is hidden on
-    // desktop since #175), so click that one to navigate home client-side.
+    // #175: the logo is in the top nav now (the left-sidebar one is hidden on desktop).
     await page.click('.nav-head:not(.is-nav-left) a[href="/"]')
     await autoRetry(
       async () => {

--- a/demo/testRun.ts
+++ b/demo/testRun.ts
@@ -268,7 +268,7 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
   })
 
   test('client-side navigation', async () => {
-    await page.click('.nav-head:not(.is-nav-left) a[href="/"]')
+    await page.click('.nav-head a[href="/"]')
     await autoRetry(
       async () => {
         await testLandingPageClient()

--- a/demo/testRun.ts
+++ b/demo/testRun.ts
@@ -268,7 +268,6 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
   })
 
   test('client-side navigation', async () => {
-    // #175: the logo is in the top nav now (the left-sidebar one is hidden on desktop).
     await page.click('.nav-head:not(.is-nav-left) a[href="/"]')
     await autoRetry(
       async () => {

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -95,11 +95,8 @@ function Layout({ children }: { children: React.ReactNode }) {
       }}
     >
       <div className={isLandingPage ? '' : 'doc-page'} style={whitespaceBuster1}>
-        {/* #175: sticky header wrapping the top nav + its dropdown, so both pin
-            together while scrolling. The modal must live inside this sticky,
-            positioned ancestor: `position: fixed` wouldn't pin it to the viewport
-            because the page wrapper sets `container-type`, which becomes the
-            containing block for fixed descendants too. */}
+        {/* #175: sticky top nav + dropdown. The modal must be inside this sticky
+            ancestor: `container-type` on the page wrapper traps `position: fixed`. */}
         <div className="nav-head-sticky" style={{ position: 'sticky', top: 0, zIndex: 100 }}>
           <NavHead />
           <MenuModal isNavLeftAlwaysHidden_={isNavLeftAlwaysHidden_} />
@@ -227,8 +224,7 @@ function NavLeft() {
         <div
           style={{
             position: 'sticky',
-            // #175: sit below the sticky top nav (was `top: 0`, back when the
-            // sidebar carried its own nav head).
+            // #175: sit below the sticky top nav.
             top: 'var(--nav-head-height)',
           }}
         >
@@ -349,10 +345,7 @@ function NavHead({ isNavLeft }: { isNavLeft?: true }) {
       style={{
         backgroundColor: 'var(--color-bg-gray)',
         position: 'relative',
-        // #175: the left nav keeps the white block-margin separator; the sticky
-        // top nav uses a soft shadow instead, so a scrolled page doesn't leave a
-        // floating white line under it (a subpixel seam exposed the white body on
-        // retina/macOS).
+        // #175: sticky top nav uses a shadow (a white border left a retina seam line); left nav keeps the border.
         ...(isNavLeft
           ? { borderBottom: 'var(--block-margin) solid var(--color-bg-white)' }
           : { boxShadow: '0 1px 2px rgba(0, 0, 0, 0.06)' }),
@@ -364,10 +357,7 @@ function NavHead({ isNavLeft }: { isNavLeft?: true }) {
           // DON'T REMOVE this container: it's needed for the `cqw` values
           container: 'container-nav-head / inline-size',
           width: '100%',
-          // #175: cap the cqw context so the spacing between nav items (derived
-          // from `cqw`) is identical on the landing page (full-width wrapper) and
-          // doc pages (wrapper capped at bodyMaxWidth). Without this the landing
-          // nav, sitting in a wider wrapper, gets wider gaps between items.
+          // #175: cap the cqw context so nav-item spacing matches between landing and doc pages.
           maxWidth: bodyMaxWidth,
           margin: '0 auto',
         }}
@@ -376,7 +366,8 @@ function NavHead({ isNavLeft }: { isNavLeft?: true }) {
           className="nav-head-content"
           style={{
             width: '100%',
-            maxWidth: navMaxWidth,
+            // #175: top nav spans the doc-page width so its logo lines up with the sidebar (same width on landing).
+            maxWidth: isNavLeft ? navMaxWidth : bodyMaxWidth,
             margin: 'auto',
             height: 'var(--nav-head-height)',
             fontSize: `min(14.2px, ${isProjectNameShort(name) ? '4.8cqw' : '4.5cqw'})`,
@@ -464,11 +455,7 @@ function getStyleLayout() {
   if (!isNavLeftAlwaysHidden()) {
     style += css`
 @container container-viewport (min-width: ${viewDesktop}px) {
-  ${/* #175 prototype: keep the full-width top nav on doc pages too, so every
-        page shows the same top nav as the landing page. Previously the top nav
-        was hidden on wide desktop and swapped for a left-sidebar nav head (logo
-        + hover-revealed links). Now the top nav stays and the left column is the
-        navigation tree only, sitting beneath it. */ ''}
+  ${/* #175: keep the full-width top nav on doc pages too; the left column is the nav tree only. */ ''}
   .nav-head.is-nav-left {
     display: none !important;
   }

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -94,7 +94,7 @@ function Layout({ children }: { children: React.ReactNode }) {
         margin: 'auto',
       }}
     >
-      <div className={isLandingPage ? '' : 'doc-page'} style={whitespaceBuster1}>
+      <div className={isLandingPage ? 'landing-page' : 'doc-page'} style={whitespaceBuster1}>
         {/* #175: top nav + dropdown. Sticky on doc pages, not the landing page.
             The modal is inside it because `container-type` on the page wrapper
             traps `position: fixed`. */}
@@ -452,6 +452,20 @@ function getStyleLayout() {
 }
 `
 
+  // #175: the top nav uses a consistent white border-bottom and no shadow on every page. Doc pages
+  // get the border from the left nav's full-width background (.nav-head-bg) on desktop and from the
+  // mobile rule below; either way drop the inline shadow. The landing page has no .nav-head-bg, so
+  // give its top nav the same direct border (and no shadow) for consistency.
+  style += css`
+.doc-page .nav-head:not(.is-nav-left) {
+  box-shadow: none !important;
+}
+.landing-page .nav-head:not(.is-nav-left) {
+  border-bottom: var(--block-margin) solid var(--color-bg-white);
+  box-shadow: none !important;
+}
+`
+
   // Desktop
   if (!isNavLeftAlwaysHidden()) {
     style += css`
@@ -469,6 +483,10 @@ function getStyleLayout() {
     --main-view-padding: 10px !important;
   }
   ${getStyleNavLeftHidden()}
+  ${/* #175: mobile hides the left nav's full-width background, so the top nav carries the same white border-bottom desktop shows there (the inline shadow is already dropped for all doc pages above). */ ''}
+  .nav-head:not(.is-nav-left) {
+    border-bottom: var(--block-margin) solid var(--color-bg-white);
+  }
 }
 `
   } else {

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -443,36 +443,13 @@ function getStyleLayout() {
   if (!isNavLeftAlwaysHidden()) {
     style += css`
 @container container-viewport (min-width: ${viewDesktop}px) {
-  .nav-head:not(.is-nav-left) {
-    display: none !important;
-  }
+  ${/* #175 prototype: keep the full-width top nav on doc pages too, so every
+        page shows the same top nav as the landing page. Previously the top nav
+        was hidden on wide desktop and swapped for a left-sidebar nav head (logo
+        + hover-revealed links). Now the top nav stays and the left column is the
+        navigation tree only, sitting beneath it. */ ''}
   .nav-head.is-nav-left {
-    .nav-head-content {
-      --icon-text-padding: min(8px, 7 * (1cqw - 2.5px));
-      & > :not(.always-shown) {
-        --padding-side: min(24px, 27 * (1cqw - 2.5px));
-      }
-      & > * {
-        flex-grow: 0.5;
-      }
-      & > .nav-head-menu-toggle {
-        flex-grow: 1;
-      }
-    }
-  }
-  .show-on-nav-hover {
-    opacity: 0;
-    transition-property: opacity;
-    pointer-events: none;
-  }
-  html:not(.unexpand-nav) {
-    & .nav-head.is-nav-left:hover .show-on-nav-hover,
-    &:has(.nav-head:hover) #menu-modal-wrapper.show-on-nav-hover,
-    &.menu-modal-show .nav-head.is-nav-left .show-on-nav-hover,
-    &.menu-modal-show #menu-modal-wrapper.show-on-nav-hover {
-      opacity: 1;
-      pointer-events: all;
-    }
+    display: none !important;
   }
 }
 @container container-viewport (max-width: ${viewDesktop - 1}px) {

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -364,6 +364,12 @@ function NavHead({ isNavLeft }: { isNavLeft?: true }) {
           // DON'T REMOVE this container: it's needed for the `cqw` values
           container: 'container-nav-head / inline-size',
           width: '100%',
+          // #175: cap the cqw context so the spacing between nav items (derived
+          // from `cqw`) is identical on the landing page (full-width wrapper) and
+          // doc pages (wrapper capped at bodyMaxWidth). Without this the landing
+          // nav, sitting in a wider wrapper, gets wider gaps between items.
+          maxWidth: bodyMaxWidth,
+          margin: '0 auto',
         }}
       >
         <div

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -336,8 +336,11 @@ function NavHead() {
       style={{
         backgroundColor: 'var(--color-bg-gray)',
         position: 'relative',
-        // #175: the single top nav uses a consistent white border-bottom and no shadow on every page.
-        borderBottom: 'var(--block-margin) solid var(--color-bg-white)',
+        // #175: consistent white separator under the top nav, drawn with box-shadow rather than
+        // border-bottom so it adds 0 layout height. A real border made the nav --block-margin taller
+        // than --nav-head-height (63→67px), and the sticky left sidebar + nav-height math key off
+        // --nav-head-height, so the 4px mismatch broke the sidebar's sticky positioning.
+        boxShadow: `0 ${blockMargin}px 0 var(--color-bg-white)`,
       }}
     >
       <div

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -220,7 +220,9 @@ function NavLeft() {
         <div
           style={{
             position: 'sticky',
-            top: 0,
+            // #175: sit below the sticky top nav (was `top: 0`, back when the
+            // sidebar carried its own nav head).
+            top: 'var(--nav-head-height)',
           }}
         >
           <NavHead isNavLeft={true} />
@@ -340,7 +342,9 @@ function NavHead({ isNavLeft }: { isNavLeft?: true }) {
       style={{
         backgroundColor: 'var(--color-bg-gray)',
         borderBottom: 'var(--block-margin) solid var(--color-bg-white)',
-        position: 'relative',
+        // #175: the top nav sticks to the top while scrolling (the left-side
+        // nav head keeps `relative` — it positions its full-width background).
+        ...(isNavLeft ? { position: 'relative' } : { position: 'sticky', top: 0, zIndex: 100 }),
       }}
     >
       {isNavLeft && <NavHeadLeftFullWidthBackground />}

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -94,9 +94,16 @@ function Layout({ children }: { children: React.ReactNode }) {
         margin: 'auto',
       }}
     >
-      <MenuModal isTopNav={isLandingPage} isNavLeftAlwaysHidden_={isNavLeftAlwaysHidden_} />
       <div className={isLandingPage ? '' : 'doc-page'} style={whitespaceBuster1}>
-        <NavHead />
+        {/* #175: sticky header wrapping the top nav + its dropdown, so both pin
+            together while scrolling. The modal must live inside this sticky,
+            positioned ancestor: `position: fixed` wouldn't pin it to the viewport
+            because the page wrapper sets `container-type`, which becomes the
+            containing block for fixed descendants too. */}
+        <div className="nav-head-sticky" style={{ position: 'sticky', top: 0, zIndex: 100 }}>
+          <NavHead />
+          <MenuModal isNavLeftAlwaysHidden_={isNavLeftAlwaysHidden_} />
+        </div>
         {content}
       </div>
       {/* Early toggling, to avoid layout jumps */}
@@ -341,10 +348,14 @@ function NavHead({ isNavLeft }: { isNavLeft?: true }) {
       className={cls(['nav-head link-hover-animation', isNavLeft && 'is-nav-left', !!navMaxWidth && 'has-max-width'])}
       style={{
         backgroundColor: 'var(--color-bg-gray)',
-        borderBottom: 'var(--block-margin) solid var(--color-bg-white)',
-        // #175: the top nav sticks to the top while scrolling (the left-side
-        // nav head keeps `relative` — it positions its full-width background).
-        ...(isNavLeft ? { position: 'relative' } : { position: 'sticky', top: 0, zIndex: 100 }),
+        position: 'relative',
+        // #175: the left nav keeps the white block-margin separator; the sticky
+        // top nav uses a soft shadow instead, so a scrolled page doesn't leave a
+        // floating white line under it (a subpixel seam exposed the white body on
+        // retina/macOS).
+        ...(isNavLeft
+          ? { borderBottom: 'var(--block-margin) solid var(--color-bg-white)' }
+          : { boxShadow: '0 1px 2px rgba(0, 0, 0, 0.06)' }),
       }}
     >
       {isNavLeft && <NavHeadLeftFullWidthBackground />}

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -98,7 +98,7 @@ function Layout({ children }: { children: React.ReactNode }) {
         {/* #175: top nav + dropdown. Sticky on doc pages, not the landing page.
             The modal is inside it because `container-type` on the page wrapper
             traps `position: fixed`. */}
-        <div className="nav-head-sticky" style={{ position: isLandingPage ? 'relative' : 'sticky', top: 0, zIndex: 100 }}>
+        <div className="nav-head-sticky" style={{ position: isLandingPage ? 'relative' : 'sticky', top: 0, zIndex: 100, boxShadow: '0 1px 2px rgba(0, 0, 0, 0.06)' }}>
           <NavHead />
           <MenuModal isNavLeftAlwaysHidden_={isNavLeftAlwaysHidden_} />
         </div>
@@ -346,10 +346,8 @@ function NavHead({ isNavLeft }: { isNavLeft?: true }) {
       style={{
         backgroundColor: 'var(--color-bg-gray)',
         position: 'relative',
-        // #175: sticky top nav uses a shadow (a white border left a retina seam line); left nav keeps the border.
-        ...(isNavLeft
-          ? { borderBottom: 'var(--block-margin) solid var(--color-bg-white)' }
-          : { boxShadow: '0 1px 2px rgba(0, 0, 0, 0.06)' }),
+        // #175: left nav keeps a white border-bottom below its header; the sticky top nav casts its shadow from the wrapper.
+        ...(isNavLeft && { borderBottom: 'var(--block-margin) solid var(--color-bg-white)' }),
       }}
     >
       {isNavLeft && <NavHeadLeftFullWidthBackground />}

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -95,9 +95,10 @@ function Layout({ children }: { children: React.ReactNode }) {
       }}
     >
       <div className={isLandingPage ? '' : 'doc-page'} style={whitespaceBuster1}>
-        {/* #175: sticky top nav + dropdown. The modal must be inside this sticky
-            ancestor: `container-type` on the page wrapper traps `position: fixed`. */}
-        <div className="nav-head-sticky" style={{ position: 'sticky', top: 0, zIndex: 100 }}>
+        {/* #175: top nav + dropdown. Sticky on doc pages, not the landing page.
+            The modal is inside it because `container-type` on the page wrapper
+            traps `position: fixed`. */}
+        <div className="nav-head-sticky" style={{ position: isLandingPage ? 'relative' : 'sticky', top: 0, zIndex: 100 }}>
           <NavHead />
           <MenuModal isNavLeftAlwaysHidden_={isNavLeftAlwaysHidden_} />
         </div>

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -98,7 +98,7 @@ function Layout({ children }: { children: React.ReactNode }) {
         {/* #175: top nav + dropdown. Sticky on doc pages, not the landing page.
             The modal is inside it because `container-type` on the page wrapper
             traps `position: fixed`. */}
-        <div className="nav-head-sticky" style={{ position: isLandingPage ? 'relative' : 'sticky', top: 0, zIndex: 100 }}>
+        <div style={{ position: isLandingPage ? 'relative' : 'sticky', top: 0, zIndex: 100 }}>
           <NavHead />
           <MenuModal isNavLeftAlwaysHidden_={isNavLeftAlwaysHidden_} />
         </div>
@@ -229,7 +229,6 @@ function NavLeft() {
             top: 'var(--nav-head-height)',
           }}
         >
-          <NavHead isNavLeft={true} />
           <div
             style={{
               backgroundColor: 'var(--color-bg-gray)',
@@ -302,29 +301,20 @@ const menuLinkStyle: React.CSSProperties = {
   justifyContent: 'center',
 }
 
-// Two <NavHead> instances are rendered:
-//  - The left-side <NavHead> shown on documentation pages on desktop
-//  - The top <NavHead> shown otherwise
-function NavHead({ isNavLeft }: { isNavLeft?: true }) {
+// A single top <NavHead> is rendered. (#175 dropped the left-sidebar nav head;
+// the left column is now the navigation tree only.)
+function NavHead() {
   const pageContext = usePageContext()
   const { navMaxWidth, name, algolia } = pageContext.globalContext.config.docpress
   const hideNavHeadLogo = pageContext.resolved.isLandingPage && !navMaxWidth
 
   const navHeadSecondary = (
     <div
-      className={cls(['nav-head-secondary', isNavLeft && 'show-on-nav-hover add-transition'])}
+      className="nav-head-secondary"
       style={{
         padding: 0,
         display: 'flex',
         height: '100%',
-        ...(isNavLeft
-          ? {
-              position: 'absolute',
-              left: '100%',
-              top: 0,
-              width: mainViewWidthMax, // guaranteed real estate
-            }
-          : {}),
       }}
     >
       {pageContext.globalContext.config.docpress.topNavigation}
@@ -342,17 +332,14 @@ function NavHead({ isNavLeft }: { isNavLeft?: true }) {
 
   return (
     <div
-      className={cls(['nav-head link-hover-animation', isNavLeft && 'is-nav-left', !!navMaxWidth && 'has-max-width'])}
+      className={cls(['nav-head link-hover-animation', !!navMaxWidth && 'has-max-width'])}
       style={{
         backgroundColor: 'var(--color-bg-gray)',
         position: 'relative',
-        // #175: sticky top nav uses a shadow (a white border left a retina seam line); left nav keeps the border.
-        ...(isNavLeft
-          ? { borderBottom: 'var(--block-margin) solid var(--color-bg-white)' }
-          : { boxShadow: '0 1px 2px rgba(0, 0, 0, 0.06)' }),
+        // #175: the single top nav uses a consistent white border-bottom and no shadow on every page.
+        borderBottom: 'var(--block-margin) solid var(--color-bg-white)',
       }}
     >
-      {isNavLeft && <NavHeadLeftFullWidthBackground />}
       <div
         style={{
           // DON'T REMOVE this container: it's needed for the `cqw` values
@@ -368,7 +355,7 @@ function NavHead({ isNavLeft }: { isNavLeft?: true }) {
           style={{
             width: '100%',
             // #175: top nav spans the doc-page width so its logo lines up with the sidebar (same width on landing).
-            maxWidth: isNavLeft ? navMaxWidth : bodyMaxWidth,
+            maxWidth: bodyMaxWidth,
             margin: 'auto',
             height: 'var(--nav-head-height)',
             fontSize: `min(14.2px, ${isProjectNameShort(name) ? '4.8cqw' : '4.5cqw'})`,
@@ -377,7 +364,7 @@ function NavHead({ isNavLeft }: { isNavLeft?: true }) {
             justifyContent: 'center',
           }}
         >
-          {!hideNavHeadLogo && <NavHeadLogo isNavLeft={isNavLeft} />}
+          {!hideNavHeadLogo && <NavHeadLogo />}
           <div className="desktop-grow" style={{ display: 'none' }} />
           {algolia && <SearchLink className="always-shown" style={menuLinkStyle} />}
           <MenuToggleMain className="always-shown nav-head-menu-toggle" style={menuLinkStyle} />
@@ -393,7 +380,7 @@ function getStyleLayout() {
   // Mobile
   style += css`
 @media(max-width: ${viewMobile}px) {
-  .nav-head:not(.is-nav-left) {
+  .nav-head {
     .nav-head-menu-toggle {
       justify-content: flex-end !important;
       padding-right: var(--main-view-padding) !important;
@@ -410,7 +397,7 @@ function getStyleLayout() {
   // Mobile + tablet
   style += css`
 @media(max-width: ${viewTablet}px) {
-  .nav-head:not(.is-nav-left) {
+  .nav-head {
     .nav-head-secondary {
       display: none !important;
     }
@@ -420,7 +407,7 @@ function getStyleLayout() {
   // Tablet
   style += css`
 @media(max-width: ${viewTablet}px) and (min-width: ${viewMobile + 1}px) {
-  .nav-head:not(.is-nav-left) {
+  .nav-head {
     .nav-head-content {
       --icon-text-padding: 8px;
       --padding-side: 20px;
@@ -431,7 +418,7 @@ function getStyleLayout() {
   // Desktop small + desktop
   style += css`
 @media(min-width: ${viewTablet + 1}px) {
-  .nav-head:not(.is-nav-left) {
+  .nav-head {
     .nav-head-content {
       --icon-text-padding: min(8px, 0.5cqw);
       --padding-side: min(20px, 1.2cqw);
@@ -452,29 +439,9 @@ function getStyleLayout() {
 }
 `
 
-  // #175: the top nav uses a consistent white border-bottom and no shadow on every page. Doc pages
-  // get the border from the left nav's full-width background (.nav-head-bg) on desktop and from the
-  // mobile rule below; either way drop the inline shadow. The landing page has no .nav-head-bg, so
-  // give its top nav the same direct border (and no shadow) for consistency.
-  style += css`
-.doc-page .nav-head:not(.is-nav-left) {
-  box-shadow: none !important;
-}
-.landing-page .nav-head:not(.is-nav-left) {
-  border-bottom: var(--block-margin) solid var(--color-bg-white);
-  box-shadow: none !important;
-}
-`
-
   // Desktop
   if (!isNavLeftAlwaysHidden()) {
     style += css`
-@container container-viewport (min-width: ${viewDesktop}px) {
-  ${/* #175: keep the full-width top nav on doc pages too; the left column is the nav tree only. */ ''}
-  .nav-head.is-nav-left {
-    display: none !important;
-  }
-}
 @container container-viewport (max-width: ${viewDesktop - 1}px) {
   #nav-left, #nav-left-margin {
     display: none;
@@ -483,10 +450,6 @@ function getStyleLayout() {
     --main-view-padding: 10px !important;
   }
   ${getStyleNavLeftHidden()}
-  ${/* #175: mobile hides the left nav's full-width background, so the top nav carries the same white border-bottom desktop shows there (the inline shadow is already dropped for all doc pages above). */ ''}
-  .nav-head:not(.is-nav-left) {
-    border-bottom: var(--block-margin) solid var(--color-bg-white);
-  }
 }
 `
   } else {
@@ -518,37 +481,7 @@ function unexpandNav() {
   }, 1000)
 }
 
-function NavHeadLeftFullWidthBackground() {
-  return (
-    <>
-      <div
-        className="nav-head-bg show-on-nav-hover add-transition"
-        style={{
-          height: '100%',
-          zIndex: -1,
-          background: 'var(--color-bg-gray)',
-          position: 'absolute',
-          left: 0,
-          top: 0,
-          boxSizing: 'content-box',
-          borderBottom: 'var(--block-margin) solid var(--color-bg-white)',
-        }}
-      />
-      <Style>{
-        // (min-width: 0px) => trick to always apply => @container seems to always require a condition
-        css`
-@container container-viewport (min-width: 0px) {
-  .nav-head-bg {
-     width: 100cqw;
-  }
-}
-`
-      }</Style>
-    </>
-  )
-}
-
-function NavHeadLogo({ isNavLeft }: { isNavLeft?: true }) {
+function NavHeadLogo() {
   const pageContext = usePageContext()
 
   const { navLogo } = pageContext.globalContext.config.docpress
@@ -588,14 +521,8 @@ function NavHeadLogo({ isNavLeft }: { isNavLeft?: true }) {
         alignItems: 'center',
         height: '100%',
         color: 'inherit',
-        ...(!isNavLeft
-          ? {
-              paddingLeft: 'var(--main-view-padding)',
-              paddingRight: 'var(--padding-side)',
-            }
-          : {
-              paddingLeft: 15,
-            }),
+        paddingLeft: 'var(--main-view-padding)',
+        paddingRight: 'var(--padding-side)',
       }}
       href="/"
       onContextMenu={!navLogo ? undefined : onContextMenu}

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -95,11 +95,9 @@ function Layout({ children }: { children: React.ReactNode }) {
       }}
     >
       <div className={isLandingPage ? 'landing-page' : 'doc-page'} style={whitespaceBuster1}>
-        {/* #175: top nav + dropdown. Sticky on doc pages, not the landing page.
-            The modal is inside it because `container-type` on the page wrapper
-            traps `position: fixed`. */}
         <div style={{ position: isLandingPage ? 'relative' : 'sticky', top: 0, zIndex: 100 }}>
           <NavHead />
+          {/* <MenuModal> is inside here because `container-type` on the page wrapper traps `position: fixed` — https://github.com/brillout/docpress/pull/177 */}
           <MenuModal isNavLeftAlwaysHidden_={isNavLeftAlwaysHidden_} />
         </div>
         {content}
@@ -225,7 +223,7 @@ function NavLeft() {
         <div
           style={{
             position: 'sticky',
-            // #175: sit below the sticky top nav.
+            // Sit below the sticky top nav
             top: 'var(--nav-head-height)',
           }}
         >
@@ -301,8 +299,6 @@ const menuLinkStyle: React.CSSProperties = {
   justifyContent: 'center',
 }
 
-// A single top <NavHead> is rendered. (#175 dropped the left-sidebar nav head;
-// the left column is now the navigation tree only.)
 function NavHead() {
   const pageContext = usePageContext()
   const { navMaxWidth, name, algolia } = pageContext.globalContext.config.docpress
@@ -336,10 +332,6 @@ function NavHead() {
       style={{
         backgroundColor: 'var(--color-bg-gray)',
         position: 'relative',
-        // #175: consistent white separator under the top nav, drawn with box-shadow rather than
-        // border-bottom so it adds 0 layout height. A real border made the nav --block-margin taller
-        // than --nav-head-height (63→67px), and the sticky left sidebar + nav-height math key off
-        // --nav-head-height, so the 4px mismatch broke the sidebar's sticky positioning.
         boxShadow: `0 ${blockMargin}px 0 var(--color-bg-white)`,
       }}
     >
@@ -348,7 +340,7 @@ function NavHead() {
           // DON'T REMOVE this container: it's needed for the `cqw` values
           container: 'container-nav-head / inline-size',
           width: '100%',
-          // #175: cap the cqw context so nav-item spacing matches between landing and doc pages.
+          // Cap the cqw context so nav-item spacing matches between landing and doc pages.
           maxWidth: bodyMaxWidth,
           margin: '0 auto',
         }}
@@ -357,7 +349,7 @@ function NavHead() {
           className="nav-head-content"
           style={{
             width: '100%',
-            // #175: top nav spans the doc-page width so its logo lines up with the sidebar (same width on landing).
+            // Top nav spans the doc-page width so its logo lines up with the sidebar (same width on landing).
             maxWidth: bodyMaxWidth,
             margin: 'auto',
             height: 'var(--nav-head-height)',

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -98,7 +98,7 @@ function Layout({ children }: { children: React.ReactNode }) {
         {/* #175: top nav + dropdown. Sticky on doc pages, not the landing page.
             The modal is inside it because `container-type` on the page wrapper
             traps `position: fixed`. */}
-        <div className="nav-head-sticky" style={{ position: isLandingPage ? 'relative' : 'sticky', top: 0, zIndex: 100, boxShadow: '0 1px 2px rgba(0, 0, 0, 0.06)' }}>
+        <div className="nav-head-sticky" style={{ position: isLandingPage ? 'relative' : 'sticky', top: 0, zIndex: 100 }}>
           <NavHead />
           <MenuModal isNavLeftAlwaysHidden_={isNavLeftAlwaysHidden_} />
         </div>
@@ -346,8 +346,10 @@ function NavHead({ isNavLeft }: { isNavLeft?: true }) {
       style={{
         backgroundColor: 'var(--color-bg-gray)',
         position: 'relative',
-        // #175: left nav keeps a white border-bottom below its header; the sticky top nav casts its shadow from the wrapper.
-        ...(isNavLeft && { borderBottom: 'var(--block-margin) solid var(--color-bg-white)' }),
+        // #175: sticky top nav uses a shadow (a white border left a retina seam line); left nav keeps the border.
+        ...(isNavLeft
+          ? { borderBottom: 'var(--block-margin) solid var(--color-bg-white)' }
+          : { boxShadow: '0 1px 2px rgba(0, 0, 0, 0.06)' }),
       }}
     >
       {isNavLeft && <NavHeadLeftFullWidthBackground />}

--- a/src/MenuModal.tsx
+++ b/src/MenuModal.tsx
@@ -22,9 +22,7 @@ function MenuModal({ isNavLeftAlwaysHidden_ }: { isNavLeftAlwaysHidden_: boolean
         id="menu-modal-wrapper"
         className="link-hover-animation add-transition show-on-nav-hover"
         style={{
-          // #175: absolute inside the sticky header wrapper, so the dropdown
-          // pins right under the nav and tracks it on scroll (it used to be
-          // anchored to the document, so it scrolled off-screen).
+          // #175: absolute inside the sticky header so the dropdown tracks the nav on scroll.
           position: 'absolute',
           width: '100%',
           top: 'var(--nav-head-height)',

--- a/src/MenuModal.tsx
+++ b/src/MenuModal.tsx
@@ -22,7 +22,7 @@ function MenuModal({ isNavLeftAlwaysHidden_ }: { isNavLeftAlwaysHidden_: boolean
         id="menu-modal-wrapper"
         className="link-hover-animation add-transition show-on-nav-hover"
         style={{
-          // #175: absolute inside the sticky header so the dropdown tracks the nav on scroll.
+          // Absolute inside the sticky header so the dropdown tracks the nav on scroll
           position: 'absolute',
           width: '100%',
           top: 'var(--nav-head-height)',

--- a/src/MenuModal.tsx
+++ b/src/MenuModal.tsx
@@ -14,7 +14,7 @@ import {
 } from './MenuModal/toggleMenuModal.js'
 import { EditLink } from './EditLink.js'
 
-function MenuModal({ isTopNav, isNavLeftAlwaysHidden_ }: { isTopNav: boolean; isNavLeftAlwaysHidden_: boolean }) {
+function MenuModal({ isNavLeftAlwaysHidden_ }: { isNavLeftAlwaysHidden_: boolean }) {
   return (
     <>
       <Style>{getStyle()}</Style>
@@ -22,7 +22,10 @@ function MenuModal({ isTopNav, isNavLeftAlwaysHidden_ }: { isTopNav: boolean; is
         id="menu-modal-wrapper"
         className="link-hover-animation add-transition show-on-nav-hover"
         style={{
-          position: isTopNav ? 'absolute' : 'fixed',
+          // #175: absolute inside the sticky header wrapper, so the dropdown
+          // pins right under the nav and tracks it on scroll (it used to be
+          // anchored to the document, so it scrolled off-screen).
+          position: 'absolute',
           width: '100%',
           top: 'var(--nav-head-height)',
           zIndex: 199, // maximum value, because docsearch's modal has `z-index: 200`

--- a/src/css/heading.css
+++ b/src/css/heading.css
@@ -13,7 +13,7 @@ h3 {
   margin-bottom: 20px;
 }
 
-/* #175: offset anchored headings below the sticky top nav. */
+/* Offset headings below the sticky top nav. */
 .doc-page :is(h1, h2, h3, h4, h5, h6) {
   scroll-margin-top: calc(var(--nav-head-height) + 16px);
 }

--- a/src/css/heading.css
+++ b/src/css/heading.css
@@ -13,6 +13,13 @@ h3 {
   margin-bottom: 20px;
 }
 
+/* #175: the sticky top nav covers the top of the viewport, so offset anchored
+   headings by the nav height (plus a little breathing room) when scrolled to via
+   a `#hash` link — otherwise the heading lands hidden under the nav. */
+.doc-page :is(h1, h2, h3, h4, h5, h6) {
+  scroll-margin-top: calc(var(--nav-head-height) + 16px);
+}
+
 .doc-page h2,
 .doc-page h3 {
   margin-bottom: 16px;

--- a/src/css/heading.css
+++ b/src/css/heading.css
@@ -13,9 +13,7 @@ h3 {
   margin-bottom: 20px;
 }
 
-/* #175: the sticky top nav covers the top of the viewport, so offset anchored
-   headings by the nav height (plus a little breathing room) when scrolled to via
-   a `#hash` link — otherwise the heading lands hidden under the nav. */
+/* #175: offset anchored headings below the sticky top nav. */
 .doc-page :is(h1, h2, h3, h4, h5, h6) {
   scroll-margin-top: calc(var(--nav-head-height) + 16px);
 }

--- a/src/css/reset.css
+++ b/src/css/reset.css
@@ -1,12 +1,6 @@
 * {
   box-sizing: border-box;
 }
-html {
-  /* Always reserve the scrollbar gutter, so the centered top nav doesn't shift a
-     few pixels when moving between a page that scrolls and one that doesn't.
-     No-op when the browser uses overlay scrollbars. */
-  scrollbar-gutter: stable;
-}
 body {
   margin: 0;
 }

--- a/src/css/reset.css
+++ b/src/css/reset.css
@@ -1,6 +1,12 @@
 * {
   box-sizing: border-box;
 }
+html {
+  /* Always reserve the scrollbar gutter, so the centered top nav doesn't shift a
+     few pixels when moving between a page that scrolls and one that doesn't.
+     No-op when the browser uses overlay scrollbars. */
+  scrollbar-gutter: stable;
+}
 body {
   margin: 0;
 }


### PR DESCRIPTION
Prototype for #175. You +1'd the direction, so here's something to look at.

## What changes
On wide desktop, doc pages used to hide the full-width top nav and swap in a left-sidebar nav head (logo + links revealed on hover). So the top nav you see on the landing page vanished the moment you entered the docs. This keeps the top nav on every page and makes the left column the navigation tree only, sitting beneath it.

The top nav is also **sticky** now: it stays pinned while you scroll, on every page. The left sidebar offsets to sit just below it.

## Before / after (doc page, 1280px wide)
- Before: top bar is just logo + Search + Docs, confined to the sidebar column width. API / Get Started / Blog / Pricing / social links / version are all gone.
- After: full-width top nav identical to the landing page, with the nav tree as a sidebar below it, both pinned on scroll.

(Screenshots to follow.)

## How
- One CSS block in `getStyleLayout()`: on wide desktop, stop hiding `.nav-head:not(.is-nav-left)` and instead hide `.nav-head.is-nav-left`. The menu modal then behaves exactly as on the landing page, so the whole `show-on-nav-hover` opacity reveal (which only existed for the collapsed left nav) drops out.
- Top nav: `position: sticky; top: 0`. Sidebar wrapper offsets from `top: 0` to `top: var(--nav-head-height)`.

Only `src/Layout.tsx`. Landing and narrow/mobile layouts keep working; landing now gets the same sticky nav.

## Open question
- I made the sticky nav apply on the landing page too (for consistency). If you'd rather keep landing exactly as it was, I can scope sticky to doc pages.

Marked draft until you're happy with the shape.