### PR TITLE
fix: restore the `nav-head-sticky` class on the sticky nav wrapper (#175)

### DIFF
--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -98,7 +98,7 @@ function Layout({ children }: { children: React.ReactNode }) {
         {/* #175: top nav + dropdown. Sticky on doc pages, not the landing page.
             The modal is inside it because `container-type` on the page wrapper
             traps `position: fixed`. */}
-        <div style={{ position: isLandingPage ? 'relative' : 'sticky', top: 0, zIndex: 100 }}>
+        <div className="nav-head-sticky" style={{ position: isLandingPage ? 'relative' : 'sticky', top: 0, zIndex: 100 }}>
           <NavHead />
           <MenuModal isNavLeftAlwaysHidden_={isNavLeftAlwaysHidden_} />
         </div>


### PR DESCRIPTION
## What

Restores `className="nav-head-sticky"` on the sticky top-nav wrapper in `src/Layout.tsx`, which was dropped when #179 was squash-merged into this branch (`c24019f`).

```diff
-  <div                            style={{ position: ... 'sticky', top: 0, zIndex: 100 }}>
+  <div className="nav-head-sticky" style={{ position: ... 'sticky', top: 0, zIndex: 100 }}>
```

## Why

The class is unused *inside* DocPress, so it has no effect on the demo. But it's a styling hook for consumer stylesheets (vike.dev / telefunc.com) that target `.nav-head-sticky` to adjust the sticky nav. Dropping the class silently disabled those overrides, which made the left-side navigation scroll with the main content. Re-adding it restores the hook.

## Notes

- Targets `feat/175-top-nav-always-visible` (not `main`) — this is a fix for the #175 nav work, routed through a `claude/*` branch because direct pushes to `feat/175-*` aren't permitted for this session.
- `pnpm run build` (src) passes ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018FzMzqSYaxQQ9SA56KSza8)_