### PR TITLE
[DIAGNOSTIC] Bisect aid: c24019f reverted in 3 isolated suspects

### DIFF
--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -229,6 +229,7 @@ function NavLeft() {
             top: 'var(--nav-head-height)',
           }}
         >
+          <NavHead isNavLeft={true} />
           <div
             style={{
               backgroundColor: 'var(--color-bg-gray)',
@@ -301,20 +302,29 @@ const menuLinkStyle: React.CSSProperties = {
   justifyContent: 'center',
 }
 
-// A single top <NavHead> is rendered. (#175 dropped the left-sidebar nav head;
-// the left column is now the navigation tree only.)
-function NavHead() {
+// Two <NavHead> instances are rendered:
+//  - The left-side <NavHead> shown on documentation pages on desktop
+//  - The top <NavHead> shown otherwise
+function NavHead({ isNavLeft }: { isNavLeft?: true }) {
   const pageContext = usePageContext()
   const { navMaxWidth, name, algolia } = pageContext.globalContext.config.docpress
   const hideNavHeadLogo = pageContext.resolved.isLandingPage && !navMaxWidth
 
   const navHeadSecondary = (
     <div
-      className="nav-head-secondary"
+      className={cls(['nav-head-secondary', isNavLeft && 'show-on-nav-hover add-transition'])}
       style={{
         padding: 0,
         display: 'flex',
         height: '100%',
+        ...(isNavLeft
+          ? {
+              position: 'absolute',
+              left: '100%',
+              top: 0,
+              width: mainViewWidthMax, // guaranteed real estate
+            }
+          : {}),
       }}
     >
       {pageContext.globalContext.config.docpress.topNavigation}
@@ -332,14 +342,17 @@ function NavHead() {
 
   return (
     <div
-      className={cls(['nav-head link-hover-animation', !!navMaxWidth && 'has-max-width'])}
+      className={cls(['nav-head link-hover-animation', isNavLeft && 'is-nav-left', !!navMaxWidth && 'has-max-width'])}
       style={{
         backgroundColor: 'var(--color-bg-gray)',
         position: 'relative',
-        // bisect: revert #179 border change — restore the subtle box-shadow (no +4px solid white border).
-        boxShadow: '0 1px 2px rgba(0, 0, 0, 0.06)',
+        // #175: sticky top nav uses a shadow (a white border left a retina seam line); left nav keeps the border.
+        ...(isNavLeft
+          ? { borderBottom: 'var(--block-margin) solid var(--color-bg-white)' }
+          : { boxShadow: '0 1px 2px rgba(0, 0, 0, 0.06)' }),
       }}
     >
+      {isNavLeft && <NavHeadLeftFullWidthBackground />}
       <div
         style={{
           // DON'T REMOVE this container: it's needed for the `cqw` values
@@ -355,7 +368,7 @@ function NavHead() {
           style={{
             width: '100%',
             // #175: top nav spans the doc-page width so its logo lines up with the sidebar (same width on landing).
-            maxWidth: bodyMaxWidth,
+            maxWidth: isNavLeft ? navMaxWidth : bodyMaxWidth,
             margin: 'auto',
             height: 'var(--nav-head-height)',
             fontSize: `min(14.2px, ${isProjectNameShort(name) ? '4.8cqw' : '4.5cqw'})`,
@@ -364,7 +377,7 @@ function NavHead() {
             justifyContent: 'center',
           }}
         >
-          {!hideNavHeadLogo && <NavHeadLogo />}
+          {!hideNavHeadLogo && <NavHeadLogo isNavLeft={isNavLeft} />}
           <div className="desktop-grow" style={{ display: 'none' }} />
           {algolia && <SearchLink className="always-shown" style={menuLinkStyle} />}
           <MenuToggleMain className="always-shown nav-head-menu-toggle" style={menuLinkStyle} />
@@ -380,7 +393,7 @@ function getStyleLayout() {
   // Mobile
   style += css`
 @media(max-width: ${viewMobile}px) {
-  .nav-head {
+  .nav-head:not(.is-nav-left) {
     .nav-head-menu-toggle {
       justify-content: flex-end !important;
       padding-right: var(--main-view-padding) !important;
@@ -397,7 +410,7 @@ function getStyleLayout() {
   // Mobile + tablet
   style += css`
 @media(max-width: ${viewTablet}px) {
-  .nav-head {
+  .nav-head:not(.is-nav-left) {
     .nav-head-secondary {
       display: none !important;
     }
@@ -407,7 +420,7 @@ function getStyleLayout() {
   // Tablet
   style += css`
 @media(max-width: ${viewTablet}px) and (min-width: ${viewMobile + 1}px) {
-  .nav-head {
+  .nav-head:not(.is-nav-left) {
     .nav-head-content {
       --icon-text-padding: 8px;
       --padding-side: 20px;
@@ -418,7 +431,7 @@ function getStyleLayout() {
   // Desktop small + desktop
   style += css`
 @media(min-width: ${viewTablet + 1}px) {
-  .nav-head {
+  .nav-head:not(.is-nav-left) {
     .nav-head-content {
       --icon-text-padding: min(8px, 0.5cqw);
       --padding-side: min(20px, 1.2cqw);
@@ -439,12 +452,15 @@ function getStyleLayout() {
 }
 `
 
-  // bisect: revert #179 border change — restore the per-page box-shadow/border overrides.
+  // #175: the top nav uses a consistent white border-bottom and no shadow on every page. Doc pages
+  // get the border from the left nav's full-width background (.nav-head-bg) on desktop and from the
+  // mobile rule below; either way drop the inline shadow. The landing page has no .nav-head-bg, so
+  // give its top nav the same direct border (and no shadow) for consistency.
   style += css`
-.doc-page .nav-head {
+.doc-page .nav-head:not(.is-nav-left) {
   box-shadow: none !important;
 }
-.landing-page .nav-head {
+.landing-page .nav-head:not(.is-nav-left) {
   border-bottom: var(--block-margin) solid var(--color-bg-white);
   box-shadow: none !important;
 }
@@ -453,6 +469,12 @@ function getStyleLayout() {
   // Desktop
   if (!isNavLeftAlwaysHidden()) {
     style += css`
+@container container-viewport (min-width: ${viewDesktop}px) {
+  ${/* #175: keep the full-width top nav on doc pages too; the left column is the nav tree only. */ ''}
+  .nav-head.is-nav-left {
+    display: none !important;
+  }
+}
 @container container-viewport (max-width: ${viewDesktop - 1}px) {
   #nav-left, #nav-left-margin {
     display: none;
@@ -461,8 +483,8 @@ function getStyleLayout() {
     --main-view-padding: 10px !important;
   }
   ${getStyleNavLeftHidden()}
-  ${/* bisect: revert #179 border change — restore the white border-bottom below desktop. */ ''}
-  .nav-head {
+  ${/* #175: mobile hides the left nav's full-width background, so the top nav carries the same white border-bottom desktop shows there (the inline shadow is already dropped for all doc pages above). */ ''}
+  .nav-head:not(.is-nav-left) {
     border-bottom: var(--block-margin) solid var(--color-bg-white);
   }
 }
@@ -496,7 +518,37 @@ function unexpandNav() {
   }, 1000)
 }
 
-function NavHeadLogo() {
+function NavHeadLeftFullWidthBackground() {
+  return (
+    <>
+      <div
+        className="nav-head-bg show-on-nav-hover add-transition"
+        style={{
+          height: '100%',
+          zIndex: -1,
+          background: 'var(--color-bg-gray)',
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          boxSizing: 'content-box',
+          borderBottom: 'var(--block-margin) solid var(--color-bg-white)',
+        }}
+      />
+      <Style>{
+        // (min-width: 0px) => trick to always apply => @container seems to always require a condition
+        css`
+@container container-viewport (min-width: 0px) {
+  .nav-head-bg {
+     width: 100cqw;
+  }
+}
+`
+      }</Style>
+    </>
+  )
+}
+
+function NavHeadLogo({ isNavLeft }: { isNavLeft?: true }) {
   const pageContext = usePageContext()
 
   const { navLogo } = pageContext.globalContext.config.docpress
@@ -536,8 +588,14 @@ function NavHeadLogo() {
         alignItems: 'center',
         height: '100%',
         color: 'inherit',
-        paddingLeft: 'var(--main-view-padding)',
-        paddingRight: 'var(--padding-side)',
+        ...(!isNavLeft
+          ? {
+              paddingLeft: 'var(--main-view-padding)',
+              paddingRight: 'var(--padding-side)',
+            }
+          : {
+              paddingLeft: 15,
+            }),
       }}
       href="/"
       onContextMenu={!navLogo ? undefined : onContextMenu}

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -336,8 +336,8 @@ function NavHead() {
       style={{
         backgroundColor: 'var(--color-bg-gray)',
         position: 'relative',
-        // #175: the single top nav uses a consistent white border-bottom and no shadow on every page.
-        borderBottom: 'var(--block-margin) solid var(--color-bg-white)',
+        // bisect: revert #179 border change — restore the subtle box-shadow (no +4px solid white border).
+        boxShadow: '0 1px 2px rgba(0, 0, 0, 0.06)',
       }}
     >
       <div
@@ -439,6 +439,17 @@ function getStyleLayout() {
 }
 `
 
+  // bisect: revert #179 border change — restore the per-page box-shadow/border overrides.
+  style += css`
+.doc-page .nav-head {
+  box-shadow: none !important;
+}
+.landing-page .nav-head {
+  border-bottom: var(--block-margin) solid var(--color-bg-white);
+  box-shadow: none !important;
+}
+`
+
   // Desktop
   if (!isNavLeftAlwaysHidden()) {
     style += css`
@@ -450,6 +461,10 @@ function getStyleLayout() {
     --main-view-padding: 10px !important;
   }
   ${getStyleNavLeftHidden()}
+  ${/* bisect: revert #179 border change — restore the white border-bottom below desktop. */ ''}
+  .nav-head {
+    border-bottom: var(--block-margin) solid var(--color-bg-white);
+  }
 }
 `
   } else {

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -98,7 +98,7 @@ function Layout({ children }: { children: React.ReactNode }) {
         {/* #175: top nav + dropdown. Sticky on doc pages, not the landing page.
             The modal is inside it because `container-type` on the page wrapper
             traps `position: fixed`. */}
-        <div style={{ position: isLandingPage ? 'relative' : 'sticky', top: 0, zIndex: 100 }}>
+        <div className="nav-head-sticky" style={{ position: isLandingPage ? 'relative' : 'sticky', top: 0, zIndex: 100 }}>
           <NavHead />
           <MenuModal isNavLeftAlwaysHidden_={isNavLeftAlwaysHidden_} />
         </div>


### PR DESCRIPTION
## Purpose

**Not a merge candidate** — a bisection aid. `c24019f` (the squash-merge of #179) is one commit, so it can't be `git bisect`'d. This branch splits its rendering-affecting changes into three isolated revert commits so the scroll regression (left nav scrolls with main content) can be pinned to one suspect.

Each commit reverts exactly one suspect; stacked, they walk `Layout.tsx` back to the pre-#179 parent (`cf0b33e`). Build passes at every commit.

## Commits (oldest → newest)

| Commit | Suspect reverted |
|---|---|
| `4fedb14` — revert 1/3 | `className="nav-head-sticky"` removal (already tried in #181) |
| `1c57550` — revert 2/3 | top-nav `box-shadow` → solid 4px white border (+4px height: 63→67px) |
| `e9e0516` — revert 3/3 | removal of the desktop-hidden `<NavHead isNavLeft>` + all `isNavLeft` paths/CSS — after this, `Layout.tsx` == `cf0b33e` |

## How to bisect

```bash
git fetch origin claude/bisect-c24019f-reverts
# rebuild src + restart your app after each checkout, test the scroll
git checkout 4fedb14   # className restored only
git checkout 1c57550   # + border reverted
git checkout e9e0516   # + tree-shake reverted (== cf0b33e Layout)
```

The commit where the bug **first disappears** identifies the culprit:
- fixed at `1c57550` → it's the **border/+4px height** change
- fixed at `e9e0516` (but not `1c57550`) → it's the **tree-shake**
- **still broken at `e9e0516`** → it's *not* in `Layout.tsx` at all (a strong signal — `c24019f` only touches `Layout.tsx` and `demo/testRun.ts`), so we look elsewhere

Note: `demo/testRun.ts`'s selector change from #179 is intentionally left as-is (it's a test file, not shipped, and not a rendering suspect). Once you know the culprit, I'll turn it into a real, minimal fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018FzMzqSYaxQQ9SA56KSza8)_