### PR TITLE
fix: top-nav separator via box-shadow (no added height) — fixes sticky sidebar (#175)

### DIFF
--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -336,8 +336,11 @@ function NavHead() {
       style={{
         backgroundColor: 'var(--color-bg-gray)',
         position: 'relative',
-        // #175: the single top nav uses a consistent white border-bottom and no shadow on every page.
-        borderBottom: 'var(--block-margin) solid var(--color-bg-white)',
+        // #175: consistent white separator under the top nav, drawn with box-shadow rather than
+        // border-bottom so it adds 0 layout height. A real border made the nav --block-margin taller
+        // than --nav-head-height (63→67px), and the sticky left sidebar + nav-height math key off
+        // --nav-head-height, so the 4px mismatch broke the sidebar's sticky positioning.
+        boxShadow: `0 ${blockMargin}px 0 var(--color-bg-white)`,
       }}
     >
       <div


### PR DESCRIPTION
## Root cause

Bisected (via #182) to the **border change** in `c24019f`: #179 swapped the top nav's `box-shadow` for a real `border-bottom: var(--block-margin) solid …`. A `border-bottom` adds to layout height, so the nav became **67px** while `--nav-head-height` stayed **63px**.

That 4px matters because `--nav-head-height` is the single source of truth keyed off by:
- the **sticky left sidebar**'s `top: var(--nav-head-height)`
- the nav-height `calc()`s (e.g. `#navigation-container` height)
- heading scroll offsets

So the actual nav no longer matched the value everything aligns to. The 4px mismatch broke the sidebar's sticky positioning — it scrolled with the main content — in browsers stricter than Chromium (which tolerated the discrepancy, why it didn't repro in my automated tests).

## Fix

Draw the same consistent white separator with `box-shadow` instead of `border-bottom`. `box-shadow` paints the 4px white line **without contributing any layout height**, so the nav stays exactly `--nav-head-height` and the sidebar math lines up again.

```diff
- borderBottom: 'var(--block-margin) solid var(--color-bg-white)',
+ boxShadow: `0 ${blockMargin}px 0 var(--color-bg-white)`,
```

One line. Visually identical white separator, zero height impact.

(Note: a CSS `var()` in the box-shadow *offset* position is rejected by the parser — it computes to `none` — so the offset is interpolated from the `blockMargin` constant instead of `var(--block-margin)`. The color `var()` is fine.)

## Verification

- `pnpm run build` (src) ✅
- Chromium: confirmed `.nav-head` is back to **63px** (was 67px) and the box-shadow renders as a 4px `rgb(253,253,253)` line — screenshot checked.
- I could not reproduce the *scroll* failure in Chromium (it tolerates the 4px), so **please confirm in the browser where you saw the bug** that the sidebar now stays put. The fix removes the exact +4px that your bisect proved is the culprit, so I'm confident — but you have the reproducing environment.

If you'd prefer the old subtle drop-shadow look instead of the white line, it's a trivial value tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018FzMzqSYaxQQ9SA56KSza8)_