### PR TITLE
feat: add `topNavSticky` per-page setting to make the top nav non-sticky

### DIFF
--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -69,7 +69,8 @@ const whitespaceBuster2: React.CSSProperties = {
 
 function Layout({ children }: { children: React.ReactNode }) {
   const pageContext = usePageContext()
-  const { isLandingPage } = pageContext.resolved
+  const { isLandingPage, pageDesign } = pageContext.resolved
+  const isTopNavSticky = !isLandingPage && (pageDesign?.topNavSticky ?? true)
 
   let content: React.JSX.Element
   if (isLandingPage) {
@@ -86,6 +87,8 @@ function Layout({ children }: { children: React.ReactNode }) {
         ['--block-margin']: `${blockMargin}px`,
         // ['--nav-head-height']: `${isLandingPage ? 70 : 63}px`,
         ['--nav-head-height']: `63px`,
+        // The offset that sticky elements (top nav, <NavLeft>) sit below. Zero when the top nav scrolls away.
+        ['--nav-head-sticky-offset']: isTopNavSticky ? 'var(--nav-head-height)' : '0px',
         ['--main-view-padding']: `${mainViewPadding}px`,
         // We don't add `container` to `body` nor `html` beacuse in Firefox it breaks the `position: fixed` of <MenuModal>
         // https://stackoverflow.com/questions/74601420/css-container-inline-size-and-fixed-child
@@ -95,7 +98,7 @@ function Layout({ children }: { children: React.ReactNode }) {
       }}
     >
       <div className={isLandingPage ? 'landing-page' : 'doc-page'} style={whitespaceBuster1}>
-        <div style={{ position: isLandingPage ? 'relative' : 'sticky', top: 0, zIndex: 100 }}>
+        <div style={{ position: isTopNavSticky ? 'sticky' : 'relative', top: 0, zIndex: 100 }}>
           <NavHead />
           {/* <MenuModal> is inside here because `container-type` on the page wrapper traps `position: fixed` — https://github.com/brillout/docpress/pull/177 */}
           <MenuModal isNavLeftAlwaysHidden_={isNavLeftAlwaysHidden_} />
@@ -223,8 +226,8 @@ function NavLeft() {
         <div
           style={{
             position: 'sticky',
-            // Sit below the sticky top nav
-            top: 'var(--nav-head-height)',
+            // Sit below the sticky top nav (or at the very top when the top nav scrolls away)
+            top: 'var(--nav-head-sticky-offset)',
           }}
         >
           <div
@@ -236,7 +239,7 @@ function NavLeft() {
               id="navigation-container"
               style={{
                 top: 0,
-                height: `calc(100vh - var(--nav-head-height) - var(--block-margin))`,
+                height: `calc(100vh - var(--nav-head-sticky-offset) - var(--block-margin))`,
                 overflowY: 'auto',
                 overscrollBehavior: 'contain',
                 paddingBottom: 40,

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -87,7 +87,7 @@ function Layout({ children }: { children: React.ReactNode }) {
         ['--block-margin']: `${blockMargin}px`,
         // ['--nav-head-height']: `${isLandingPage ? 70 : 63}px`,
         ['--nav-head-height']: `63px`,
-        // The offset that sticky elements (top nav, <NavLeft>) sit below. Zero when the top nav scrolls away.
+        // Offset for elements sitting below the sticky top nav
         ['--nav-head-sticky-offset']: isTopNavSticky ? 'var(--nav-head-height)' : '0px',
         ['--main-view-padding']: `${mainViewPadding}px`,
         // We don't add `container` to `body` nor `html` beacuse in Firefox it breaks the `position: fixed` of <MenuModal>
@@ -226,7 +226,7 @@ function NavLeft() {
         <div
           style={{
             position: 'sticky',
-            // Sit below the sticky top nav (or at the very top when the top nav scrolls away)
+            // Sit below the sticky top nav (or at the very top when the top nav isn't sticky)
             top: 'var(--nav-head-sticky-offset)',
           }}
         >

--- a/src/css/heading.css
+++ b/src/css/heading.css
@@ -13,9 +13,9 @@ h3 {
   margin-bottom: 20px;
 }
 
-/* Offset headings below the sticky top nav. */
+/* Offset headings below the sticky top nav (no offset when the top nav scrolls away). */
 .doc-page :is(h1, h2, h3, h4, h5, h6) {
-  scroll-margin-top: calc(var(--nav-head-height) + 16px);
+  scroll-margin-top: calc(var(--nav-head-sticky-offset) + 16px);
 }
 
 .doc-page h2,

--- a/src/css/heading.css
+++ b/src/css/heading.css
@@ -13,7 +13,7 @@ h3 {
   margin-bottom: 20px;
 }
 
-/* Offset headings below the sticky top nav (no offset when the top nav scrolls away). */
+/* Offset headings below the sticky top nav (no offset if top nav isn't sticky). */
 .doc-page :is(h1, h2, h3, h4, h5, h6) {
   scroll-margin-top: calc(var(--nav-head-sticky-offset) + 16px);
 }

--- a/src/types/Heading.ts
+++ b/src/types/Heading.ts
@@ -28,6 +28,12 @@ type PageDesign = {
   hideTitle?: true
   hideMenuLeft?: true
   contentMaxWidth?: number
+  /**
+   * Whether the top navigation sticks to the top of the viewport while scrolling.
+   *
+   * @default true
+   */
+  topNavSticky?: boolean
 }
 
 type HeadingDetachedResolved = Omit<HeadingResolved, 'level' | 'linkBreadcrumb'> & {


### PR DESCRIPTION
## What

Adds a new per-page setting `pageDesign.topNavSticky?: boolean` (default `true`).

Setting `pageDesign: { topNavSticky: false }` on a page makes the top navigation scroll away with the page content instead of sticking to the top of the viewport. This will be used for vike.dev/new.

## How

- New `topNavSticky` field on the `PageDesign` type (alongside `hideTitle`, `hideMenuLeft`, `contentMaxWidth`), documented with `@default true`. It's resolved per-page via `pageContext.resolved.pageDesign`.
- A new `--nav-head-sticky-offset` CSS variable drives the offset that sticky elements sit below:
  - `var(--nav-head-height)` when the top nav is sticky
  - `0px` when it's non-sticky
- The top-nav wrapper uses `position: relative` instead of `sticky` when the setting is off.
- `<NavLeft>`'s sticky `top`, the navigation container height, and heading `scroll-margin-top` (`heading.css`) all reference `--nav-head-sticky-offset`, so they collapse to the right values when the nav scrolls away.

The default behavior is unchanged (top nav stays sticky on doc pages, as introduced in #177).

## Testing

- `pnpm run build` ✅
- `pnpm run test:types` ✅
- `pnpm run test:units` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)