### PR TITLE
fix: make `<Link text />` throw in favor of `<Link>...</Link>`

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -30,9 +30,11 @@ function Link({
     href.startsWith('/') || href.startsWith('#'),
     `<Link href /> prop \`href==='${href}'\` but should start with '/' or '#'`,
   )
-  assertUsage(!text || !children, 'Cannot use both `text` or `children`')
-  // assertWarning(!text, 'prop `text` is deprecated')
-  text = text ?? children
+  assertUsage(
+    !text,
+    'The `text` prop of `<Link>` is deprecated, use `<Link>...</Link>` instead of `<Link text="..." />`',
+  )
+  text = children
 
   const linkTextData = getLinkTextData({ href, pageContext, doNotInferSectionTitle, noWarning })
   if (!text) {


### PR DESCRIPTION
## What

Removes the `text` prop of `<Link>`: passing `<Link text="..." />` now throws an `assertUsage` error directing the user to the children-based form `<Link>...</Link>`.

## Why

The `text` prop was previously deprecated (the deprecation warning was commented out). This change makes its usage a hard error to complete the removal, keeping a single canonical way to provide link text via children.

## Changes

- `src/components/Link.tsx`: replaced the `!text || !children` usage check and the `text = text ?? children` fallback with an `assertUsage(!text, ...)` that throws when `text` is passed, followed by `text = children`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtRu8jfPnJX4v4EZXaHPho)_