### PR TITLE
fix: Hide `+choices` dropdown and show upon hovering

### DIFF
--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -7,14 +7,19 @@
   --transition-select-list-duration: 180ms;
   --transition-select-option-duration: 120ms;
   --transition-select-list: top var(--transition-select-list-duration) cubic-bezier(0.2, 0.9, 0.2, 1), clip-path
-    var(--transition-select-list-duration) ease-in-out;
+    var(--transition-select-list-duration) ease-in-out, opacity 500ms ease-in-out !important;
   --transition-select-option: background var(--transition-select-option-duration) ease;
   --transition-select-icon: filter 500ms ease, opacity 500ms ease;
+
+  &:hover {
+    .show-on-hover {
+      opacity: 1;
+    }
+  }
 
   .choice-group__selects {
     position: absolute;
     display: flex;
-    flex-direction: row-reverse;
     gap: 2px;
     top: var(--top-position);
     right: 42px;
@@ -37,6 +42,10 @@
     border-radius: var(--border-radius);
     min-width: max-content;
     transition: var(--transition-select-list);
+  }
+
+  .show-on-hover {
+    opacity: 0;
   }
 
   .choice-select__border {
@@ -114,7 +123,7 @@
   }
 
   .choice-select__list:not(.hovered) {
-    transition: none;
+    transition: opacity 200ms ease-in-out;
     .choice-select__border {
       transition: none;
     }
@@ -143,6 +152,9 @@
   * https://github.com/brillout/docpress/blob/08b63e867c4c052479e19a6943ca5535b2762d02/src/css/code/block.css#L40-L56
   */
   @media not all and (hover: hover) and (pointer: fine) {
+    .choice-select__list {
+      opacity: 1 !important;
+    }
     .choice-select__option {
       padding: 5px;
     }

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -21,6 +21,7 @@
   .choice-group__selects {
     position: absolute;
     display: flex;
+    flex-direction: row-reverse;
     gap: 2px;
     top: var(--top-position);
     right: 42px;

--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -1,3 +1,10 @@
+.choice-group-container.always-show {
+  .choice-group__selects,
+  .copy-button {
+    opacity: 1 !important;
+  }
+}
+
 .choice-group-container {
   position: relative;
 
@@ -7,15 +14,9 @@
   --transition-select-list-duration: 180ms;
   --transition-select-option-duration: 120ms;
   --transition-select-list: top var(--transition-select-list-duration) cubic-bezier(0.2, 0.9, 0.2, 1), clip-path
-    var(--transition-select-list-duration) ease-in-out, opacity 500ms ease-in-out !important;
+    var(--transition-select-list-duration) ease-in-out;
   --transition-select-option: background var(--transition-select-option-duration) ease;
   --transition-select-icon: filter 500ms ease, opacity 500ms ease;
-
-  &:hover {
-    .show-on-hover {
-      opacity: 1;
-    }
-  }
 
   .choice-group__selects {
     position: absolute;
@@ -23,6 +24,12 @@
     gap: 2px;
     top: var(--top-position);
     right: 42px;
+    opacity: 0;
+    transition: opacity 200ms ease-in-out;
+
+    &:hover {
+      opacity: 1;
+    }
   }
 
   .choice-select__list {
@@ -42,10 +49,6 @@
     border-radius: var(--border-radius);
     min-width: max-content;
     transition: var(--transition-select-list);
-  }
-
-  .show-on-hover {
-    opacity: 0;
   }
 
   .choice-select__border {
@@ -123,7 +126,7 @@
   }
 
   .choice-select__list:not(.hovered) {
-    transition: opacity 200ms ease-in-out;
+    transition: none;
     .choice-select__border {
       transition: none;
     }
@@ -152,7 +155,8 @@
   * https://github.com/brillout/docpress/blob/08b63e867c4c052479e19a6943ca5535b2762d02/src/css/code/block.css#L40-L56
   */
   @media not all and (hover: hover) and (pointer: fine) {
-    .choice-select__list {
+    .choice-group__selects,
+    .copy-button {
       opacity: 1 !important;
     }
     .choice-select__option {
@@ -266,6 +270,18 @@
       top: calc(6 * var(--option-height));
     }
   }
+}
+
+.choice-group-container:has(.choice-group__selects:hover) .copy-button {
+  opacity: 1;
+}
+
+.choice-group:has(.choice:hover) .copy-button {
+  opacity: 1;
+}
+
+.choice-group:has(.choice:hover) ~ .choice-group__selects {
+  opacity: 1;
 }
 
 .choice-group {

--- a/src/code-blocks/components/ChoiceGroup.tsx
+++ b/src/code-blocks/components/ChoiceGroup.tsx
@@ -14,8 +14,10 @@ function ChoiceGroupContainer({
   choiceGroupAll,
 }: { children: React.ReactNode; choiceGroupAll: ChoiceGroupWithParent[] }) {
   const renderCustomSelect = (choiceGroupAll ?? []).some((choiceGroup) => choiceGroup.lvl === 0 && !choiceGroup.hidden)
+  const alwaysShow = (choiceGroupAll ?? []).some((choiceGroup) => renderCustomSelect && !!choiceGroup.alwaysShow)
+
   return (
-    <div className="choice-group-container">
+    <div className={cls(['choice-group-container', alwaysShow && 'always-show'])}>
       {children}
       {renderCustomSelect && (
         <div className={`choice-group__selects`}>
@@ -53,15 +55,7 @@ const OPTION_HEIGHT = 25
 function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
   const radioId = useId()
   const choicesAll = usePageContext().resolved.choices
-  const {
-    name: groupName,
-    emptyChoices,
-    default: defaultChoice,
-    hidden,
-    parentChoiceGroup,
-    isBuiltIn,
-    hoverVisibility,
-  } = choiceGroup
+  const { name: groupName, emptyChoices, default: defaultChoice, hidden, parentChoiceGroup, isBuiltIn } = choiceGroup
   const choices = (isBuiltIn ? choiceGroup : choicesAll![groupName]!).choices
   const [selectedChoiceStored, setSelectedChoice] = useCurrentSelection(groupName, defaultChoice)
   const selectedChoice = getAvailableChoice(selectedChoiceStored, choices, emptyChoices, defaultChoice)
@@ -91,7 +85,6 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
         'choice-select__list',
         (isHidden || isEmptyChoice(selectedChoice)) && 'hidden',
         isHovered && 'hovered',
-        hoverVisibility && 'show-on-hover',
       ])}
       style={{ '--option-height': `${OPTION_HEIGHT}px`, '--choice-count': filteredChoices.length }}
       onPointerDownCapture={(e) => (lastPointerType.current = e.pointerType)}

--- a/src/code-blocks/components/ChoiceGroup.tsx
+++ b/src/code-blocks/components/ChoiceGroup.tsx
@@ -53,7 +53,15 @@ const OPTION_HEIGHT = 25
 function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
   const radioId = useId()
   const choicesAll = usePageContext().resolved.choices
-  const { name: groupName, emptyChoices, default: defaultChoice, hidden, parentChoiceGroup, isBuiltIn } = choiceGroup
+  const {
+    name: groupName,
+    emptyChoices,
+    default: defaultChoice,
+    hidden,
+    parentChoiceGroup,
+    isBuiltIn,
+    hoverVisibility,
+  } = choiceGroup
   const choices = (isBuiltIn ? choiceGroup : choicesAll![groupName]!).choices
   const [selectedChoiceStored, setSelectedChoice] = useCurrentSelection(groupName, defaultChoice)
   const selectedChoice = getAvailableChoice(selectedChoiceStored, choices, emptyChoices, defaultChoice)
@@ -83,7 +91,7 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
         'choice-select__list',
         (isHidden || isEmptyChoice(selectedChoice)) && 'hidden',
         isHovered && 'hovered',
-        !isBuiltIn && 'show-on-hover',
+        hoverVisibility && 'show-on-hover',
       ])}
       style={{ '--option-height': `${OPTION_HEIGHT}px`, '--choice-count': filteredChoices.length }}
       onPointerDownCapture={(e) => (lastPointerType.current = e.pointerType)}

--- a/src/code-blocks/components/ChoiceGroup.tsx
+++ b/src/code-blocks/components/ChoiceGroup.tsx
@@ -83,6 +83,7 @@ function CustomSelect({ choiceGroup }: { choiceGroup: ChoiceGroupWithParent }) {
         'choice-select__list',
         (isHidden || isEmptyChoice(selectedChoice)) && 'hidden',
         isHovered && 'hovered',
+        !isBuiltIn && 'show-on-hover',
       ])}
       style={{ '--option-height': `${OPTION_HEIGHT}px`, '--choice-count': filteredChoices.length }}
       onPointerDownCapture={(e) => (lastPointerType.current = e.pointerType)}

--- a/src/code-blocks/components/Pre.css
+++ b/src/code-blocks/components/Pre.css
@@ -22,7 +22,8 @@ pre {
     height: 25px;
     width: 30px;
     background-color: #f7f7f7;
-    transition: background-color 0.4s ease-in-out;
+    opacity: 0;
+    transition: background-color 0.4s ease-in-out, opacity 200ms ease-in-out;
 
     &:not(:hover) {
       background-color: #eee;

--- a/src/code-blocks/components/Pre.css
+++ b/src/code-blocks/components/Pre.css
@@ -14,6 +14,12 @@ pre {
     position: relative;
   }
 
+  &:hover {
+    .copy-button {
+      opacity: 1;
+    }
+  }
+
   .copy-button {
     position: absolute !important;
     top: 10px;

--- a/src/code-blocks/utils/generateChoiceGroupCode.ts
+++ b/src/code-blocks/utils/generateChoiceGroupCode.ts
@@ -33,7 +33,6 @@ const CHOICES_BUILT_IN: NonNullable<Config['choices']> = {
       },
     ],
     default: 'JavaScript',
-    hoverVisibility: true,
   },
   pkgManager: {
     choices: [

--- a/src/code-blocks/utils/generateChoiceGroupCode.ts
+++ b/src/code-blocks/utils/generateChoiceGroupCode.ts
@@ -47,7 +47,7 @@ const CHOICES_BUILT_IN: NonNullable<Config['choices']> = {
       { name: 'Yarn', icon: YARN_ICON, iconStyle: { height: '12px' } },
     ],
     default: 'npm',
-    hoverVisibility: false,
+    alwaysShow: true,
   },
 }
 
@@ -161,7 +161,7 @@ function resolveChoiceGroupNodes(choiceNodes: ChoiceNode[]) {
     name: groupName,
     ...group,
     emptyChoices,
-    hoverVisibility: group.hoverVisibility !== false,
+    alwaysShow: !!group.alwaysShow,
   }
 
   const mergedChoiceNodes: ChoiceNode[] = choiceGroup.choices.map((choice) => {

--- a/src/code-blocks/utils/generateChoiceGroupCode.ts
+++ b/src/code-blocks/utils/generateChoiceGroupCode.ts
@@ -33,6 +33,7 @@ const CHOICES_BUILT_IN: NonNullable<Config['choices']> = {
       },
     ],
     default: 'JavaScript',
+    hoverVisibility: true,
   },
   pkgManager: {
     choices: [
@@ -47,6 +48,7 @@ const CHOICES_BUILT_IN: NonNullable<Config['choices']> = {
       { name: 'Yarn', icon: YARN_ICON, iconStyle: { height: '12px' } },
     ],
     default: 'npm',
+    hoverVisibility: false,
   },
 }
 
@@ -160,6 +162,7 @@ function resolveChoiceGroupNodes(choiceNodes: ChoiceNode[]) {
     name: groupName,
     ...group,
     emptyChoices,
+    hoverVisibility: group.hoverVisibility !== false,
   }
 
   const mergedChoiceNodes: ChoiceNode[] = choiceGroup.choices.map((choice) => {

--- a/src/types/Config.ts
+++ b/src/types/Config.ts
@@ -85,5 +85,10 @@ type ChoiceItem = {
 type Choice = {
   choices: (string | ChoiceItem)[]
   default: string
-  hoverVisibility?: boolean
+  /**
+   * Whether to always show the dropdown.
+   *
+   * @default false
+   */
+  alwaysShow?: boolean
 }

--- a/src/types/Config.ts
+++ b/src/types/Config.ts
@@ -85,4 +85,5 @@ type ChoiceItem = {
 type Choice = {
   choices: (string | ChoiceItem)[]
   default: string
+  hoverVisibility?: boolean
 }


### PR DESCRIPTION
closes #186 

@brillout, WDYT?

I wasn't sure which commit prefix to use, so I left it out. Should I add one?