### PR TITLE
fix: always show copy button on touch devices, not only in ChoiceGroup

### DIFF
--- a/src/code-blocks/components/ChoiceGroup.css
+++ b/src/code-blocks/components/ChoiceGroup.css
@@ -156,8 +156,7 @@
   * https://github.com/brillout/docpress/blob/08b63e867c4c052479e19a6943ca5535b2762d02/src/css/code/block.css#L40-L56
   */
   @media not all and (hover: hover) and (pointer: fine) {
-    .choice-group__selects,
-    .copy-button {
+    .choice-group__selects {
       opacity: 1 !important;
     }
     .choice-select__option {

--- a/src/css/code/block.css
+++ b/src/css/code/block.css
@@ -38,6 +38,9 @@ figure[data-rehype-pretty-code-figure] {
  *  - https://stackoverflow.com/questions/23885255/how-to-remove-ignore-hover-css-style-on-touch-devices/64553121#64553121
  */
 @media not all and (hover: hover) and (pointer: fine) {
+  .copy-button {
+    opacity: 1 !important;
+  }
   @container container-viewport (max-width: 620px) {
     pre > code {
       font-size: 0.7em !important;


### PR DESCRIPTION
I missed this in the previous PR (#191) . This moves the touch-device `.copy-button` visibility rule out of ChoiceGroup, since the copy button isn't always rendered there.